### PR TITLE
When user drags inactive object, make sure he won't scale it instead

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -413,6 +413,11 @@
       if (target && target.selectable && !shouldGroup) {
         this._beforeTransform(e, target);
         this._setupCurrentTransform(e, target);
+        // activate object after transform setup to make sure that corners detection is valid
+        if (target !== this.getActiveGroup() && target !== this.getActiveObject()) {
+          this.deactivateAll();
+          this.setActiveObject(target, e);
+        }
       }
       // we must renderAll so that active image is placed on the top canvas
       shouldRender && this.renderAll();
@@ -432,11 +437,6 @@
       // determine if it's a drag or rotate case
       if ((corner = target._findTargetCorner(this.getPointer(e)))) {
         this.onBeforeScaleRotate(target);
-      }
-
-      if (target !== this.getActiveGroup() && target !== this.getActiveObject()) {
-        this.deactivateAll();
-        this.setActiveObject(target, e);
       }
     },
 


### PR DESCRIPTION
To replicate the issue using current release of FabricJS:
1. Open http://fabricjs.com/.
2. Move your mouse pointer **exactly** to the corner of a red rectangle.
3. Do **not** select the rectangle, note that 'move' cursor is visible.
4. Drag the rectangle.

I would expect that object would be moved, but instead it's scaled, as exactly under the mouse pointer there is a control point (invisible at the beginning, until the object is selected).

The problem seems to be here:
https://github.com/kangax/fabric.js/blob/818ab118b30a9205a0e57620452b08bb8f5f18cc/src/mixins/canvas_events.mixin.js#L414-L415

`_findTargetCorner` checks whether the target is active (what makes sense). It's called twice, once in `_beforeTransform` and the second time in `_setupCurrentTransform`. However the target is activated in the meantime, in `_beforeTransform`. So the second call to `_findTargetCorner` actually returns corner and scaling is being activated. I've just moved target activation out of `_beforeTransform` and it seems to fix the problem for me. These functions are used only in this context, so hopefully it's not a risky change.

Regards,
Piotr