### PR TITLE
Use hiddenTextArea to generate inputs for IText - POC

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -12,9 +12,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     fabric.document.body.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
-    fabric.util.addListener(this.hiddenTextarea, 'keypress', this.onKeyPress.bind(this));
-    fabric.util.addListener(this.hiddenTextarea, 'copy', this.copy.bind(this));
-    fabric.util.addListener(this.hiddenTextarea, 'paste', this.paste.bind(this));
+    fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));
 
     if (!this._clickHandlerInitialized && this.canvas) {
       fabric.util.addListener(this.canvas.upperCanvasEl, 'click', this.onClick.bind(this));
@@ -26,13 +24,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @private
    */
   _keysMap: {
-    8:  'removeChars',
-    13: 'insertNewline',
     37: 'moveCursorLeft',
     38: 'moveCursorUp',
     39: 'moveCursorRight',
-    40: 'moveCursorDown',
-    46: 'forwardDelete'
+    40: 'moveCursorDown'
   },
 
   /**
@@ -40,12 +35,39 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    */
   _ctrlKeysMap: {
     65: 'selectAll',
-    88: 'cut'
+    // TODO: LINE LEFT AND LINE RIGHT
+    // 37: 'moveCursorLineLeft',
+    // 39: 'moveCursorLineRight'
   },
 
   onClick: function() {
     // No need to trigger click event here, focus is enough to have the keyboard appear on Android
     this.hiddenTextarea && this.hiddenTextarea.focus();
+  },
+
+  _doGetCaretPosition: function (textArea) {
+    var caretPos = 0;
+    // IE Support
+    if (document.selection) {
+      textArea.focus();
+      var sel = document.selection.createRange();
+
+      sel.moveStart('character', -textArea.value.length);
+
+      caretPos = sel.text.length;
+    }
+    // Firefox support
+    else if (textArea.selectionStart || textArea.selectionStart == '0')
+      caretPos = textArea.selectionStart;
+    return caretPos;
+  },
+
+  onInput: function (e) {
+    var cp = this._doGetCaretPosition(this.hiddenTextarea);
+    this.text = '';
+    this.insertChars(e.srcElement.value);
+    this.setSelectionStart(cp);
+    this.setSelectionEnd(cp);
   },
 
   /**


### PR DESCRIPTION
I had problems with some inputs at iText that need two separated keystrokes, like discussed at https://github.com/kangax/fabric.js/issues/1175.
I'm not sure if I can solve the problem for Mac way of doing this, but for linux/windows I have a solution that may clean a lot of code and complexity from itext_key_behavior.mixin.js.

That's the idea: instead of listening some basic events like 'keypress' to handle input and mapping all user possible actions, we can let the textarea handle it and get it's input. In that way, the only thing that we've to care is keeping the caret at right position.

I made a POC to know if you have interest in changing the aproach. Chars like 'áéíâô' are now accepted. It works like an textarea. I didn't yet implement ctrl+left/right arrow, so in that case cursor become wrong-placed. 

If you have interest, I can continue development focusing on chrome/linux, and I hope some help to fix the behavior for others browsers/OS.
If you don't, I'll just create a new fabric class at my code and use this aproach, because it's easier for latin languages inputs.