### PR TITLE
Refactor accessors

### DIFF
--- a/build.js
+++ b/build.js
@@ -144,6 +144,7 @@ var filesToInclude = [
   ifSpecifiedDependencyInclude('serialization', 'json', 'lib/json2.js'),
   ifSpecifiedInclude('gestures', 'lib/event.js'),
 
+  'src/mixins/accessors.mixin.js',
   'src/mixins/observable.mixin.js',
   'src/mixins/collection.mixin.js',
 

--- a/src/mixins/accessors.mixin.js
+++ b/src/mixins/accessors.mixin.js
@@ -1,0 +1,256 @@
+(function() {
+  fabric.accessors = {
+    getBackgroundColor: function() {
+      return this.get('backgroundColor');
+    },
+    setBackgroundColor: function(value) {
+      this.set('backgroundColor', value);
+      return this;
+    },
+    getVisible: function() {
+      return this.get('visible');
+    },
+    setVisible: function(value) {
+      this.set('visible', value);
+      return this;
+    },
+    getClipTo: function() {
+      return this.get('clipTo');
+    },
+    setClipTo: function(value) {
+      this.set('clipTo', value);
+      return this;
+    },
+    getShadow: function() {
+      return this.get('shadow');
+    },
+    setShadow: function(value) {
+      this.set('shadow', value);
+      return this;
+    },
+    getFillRule: function() {
+      return this.get('fillRule');
+    },
+    setFillRule: function(value) {
+      this.set('fillRule', value);
+      return this;
+    },
+    getFill: function() {
+      return this.get('fill');
+    },
+    setFill: function(value) {
+      this.set('fill', value);
+      return this;
+    },
+    getOpacity: function() {
+      return this.get('opacity');
+    },
+    setOpacity: function(value) {
+      this.set('opacity', value);
+      return this;
+    },
+    getAngle: function() {
+      return this.get('angle');
+    },
+    setAngle: function(value) {
+      this.set('angle', value);
+      return this;
+    },
+    getStrokeMiterLimit: function() {
+      return this.get('strokeMiterLimit');
+    },
+    setStrokeMiterLimit: function(value) {
+      this.set('strokeMiterLimit', value);
+      return this;
+    },
+    getStrokeLineJoin: function() {
+      return this.get('strokeLineJoin');
+    },
+    setStrokeLineJoin: function(value) {
+      this.set('strokeLineJoin', value);
+      return this;
+    },
+    getStrokeLineCap: function() {
+      return this.get('strokeLineCap');
+    },
+    setStrokeLineCap: function(value) {
+      this.set('strokeLineCap', value);
+      return this;
+    },
+    getStrokeDashArray: function() {
+      return this.get('strokeDashArray');
+    },
+    setStrokeDashArray: function(value) {
+      this.set('strokeDashArray', value);
+      return this;
+    },
+    getStrokeWidth: function() {
+      return this.get('strokeWidth');
+    },
+    setStrokeWidth: function(value) {
+      this.set('strokeWidth', value);
+      return this;
+    },
+    getStroke: function() {
+      return this.get('stroke');
+    },
+    setStroke: function(value) {
+      this.set('stroke', value);
+      return this;
+    },
+    getTransformMatrix: function() {
+      return this.get('transformMatrix');
+    },
+    setTransformMatrix: function(value) {
+      this.set('transformMatrix', value);
+      return this;
+    },
+    getOriginY: function() {
+      return this.get('originY');
+    },
+    setOriginY: function(value) {
+      this.set('originY', value);
+      return this;
+    },
+    getOriginX: function() {
+      return this.get('originX');
+    },
+    setOriginX: function(value) {
+      this.set('originX', value);
+      return this;
+    },
+    getFlipY: function() {
+      return this.get('flipY');
+    },
+    setFlipY: function(value) {
+      this.set('flipY', value);
+      return this;
+    },
+    getFlipX: function() {
+      return this.get('flipX');
+    },
+    setFlipX: function(value) {
+      this.set('flipX', value);
+      return this;
+    },
+    getScaleY: function() {
+      return this.get('scaleY');
+    },
+    setScaleY: function(value) {
+      this.set('scaleY', value);
+      return this;
+    },
+    getScaleX: function() {
+      return this.get('scaleX');
+    },
+    setScaleX: function(value) {
+      this.set('scaleX', value);
+      return this;
+    },
+    getHeight: function() {
+      return this.get('height');
+    },
+    setHeight: function(value) {
+      this.set('height', value);
+      return this;
+    },
+    getWidth: function() {
+      return this.get('width');
+    },
+    setWidth: function(value) {
+      this.set('width', value);
+      return this;
+    },
+    getLeft: function() {
+      return this.get('left');
+    },
+    setLeft: function(value) {
+      this.set('left', value);
+      return this;
+    },
+    getTop: function() {
+      return this.get('top');
+    },
+    setTop: function(value) {
+      this.set('top', value);
+      return this;
+    },
+    getPath: function() {
+      return this.get('path');
+    },
+    setPath: function(value) {
+      this.set('path', value);
+      return this;
+    },
+    getUseNative: function() {
+      return this.get('useNative');
+    },
+    setUseNative: function(value) {
+      this.set('useNative', value);
+      return this;
+    },
+    getTextBackgroundColor: function() {
+      return this.get('textBackgroundColor');
+    },
+    setTextBackgroundColor: function(value) {
+      this.set('textBackgroundColor', value);
+      return this;
+    },
+    getLineHeight: function() {
+      return this.get('lineHeight');
+    },
+    setLineHeight: function(value) {
+      this.set('lineHeight', value);
+      return this;
+    },
+    getFontStyle: function() {
+      return this.get('fontStyle');
+    },
+    setFontStyle: function(value) {
+      this.set('fontStyle', value);
+      return this;
+    },
+    getTextAlign: function() {
+      return this.get('textAlign');
+    },
+    setTextAlign: function(value) {
+      this.set('textAlign', value);
+      return this;
+    },
+    getTextDecoration: function() {
+      return this.get('textDecoration');
+    },
+    setTextDecoration: function(value) {
+      this.set('textDecoration', value);
+      return this;
+    },
+    getText: function() {
+      return this.get('text');
+    },
+    setText: function(value) {
+      this.set('text', value);
+      return this;
+    },
+    getFontSize: function() {
+      return this.get('fontSize');
+    },
+    setFontSize: function(value) {
+      this.set('fontSize', value);
+      return this;
+    },
+    getFontWeight: function() {
+      return this.get('fontWeight');
+    },
+    setFontWeight: function(value) {
+      this.set('fontWeight', value);
+      return this;
+    },
+    getFontFamily: function() {
+      return this.get('fontFamily');
+    },
+    setFontFamily: function(value) {
+      this.set('fontFamily', value);
+      return this;
+    }
+  };
+}());

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -428,16 +428,11 @@
             setterName = 'set' + capitalizedPropName,
             getterName = 'get' + capitalizedPropName;
 
-        // using `new Function` for better introspection
         if (!proto[getterName]) {
-          proto[getterName] = (function(property) {
-            return new Function('return this.get("' + property + '")');
-          })(propName);
+          proto[getterName] = fabric.accessors[getterName];
         }
         if (!proto[setterName]) {
-          proto[setterName] = (function(property) {
-            return new Function('value', 'return this.set("' + property + '", value)');
-          })(propName);
+          proto[setterName] = fabric.accessors[setterName];
         }
       }
     },


### PR DESCRIPTION
Predefine the accessors methods as a mixing instead of creating them on runtime per class, while inherit only the needed methods for the class.
Fixes #1621 