### PR TITLE
Aligning guidelines: remove line after render

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -191,6 +191,8 @@ function initAligningGuidelines(canvas) {
     for (var i = horizontalLines.length; i--; ) {
       drawHorizontalLine(horizontalLines[i]);
     }
+    
+    verticalLines.length = horizontalLines.length = 0;
   });
 
   canvas.on('mouse:up', function() {


### PR DESCRIPTION
I know this is not an official fabric.js lib, so feel free to remove this PR.

After using aligning guidelines with transparent lines (opacity=0.5), it seems that vertical and horizontal lines are only removed after a mouse up (while new lines are created after each object:moving).

So as long as you don't "mouse up", new lines are created and "superimposed" (which is visible only with semi-transparent lines).

Fix this bug: remove lines after each render.