### PR TITLE
Fix requireJS compatibility issue

### DIFF
--- a/dist/fabric.require.js
+++ b/dist/fabric.require.js
@@ -23397,11 +23397,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
 window.fabric = fabric;
 
-// make sure exports.fabric is always defined when used as 'global' later scopes
-var exports = exports || {};
-exports.fabric = fabric;
-
-if (typeof define === 'function' && define.amd) {
+f (typeof define === 'function' && define.amd) {
   define([], function() { return fabric });
 }
 

--- a/src/amd/requirejs.js
+++ b/src/amd/requirejs.js
@@ -2,10 +2,6 @@
 
 window.fabric = fabric;
 
-// make sure exports.fabric is always defined when used as 'global' later scopes
-var exports = exports || {};
-exports.fabric = fabric;
-
 if (typeof define === 'function' && define.amd) {
   define([], function() { return fabric });
 }


### PR DESCRIPTION
last few lines in `src/amd/require.js` adds a  global **export** variable

however, when using in requirejs, the added global export will cause other module fails to load
cause the added global export will make other module thought they're in the wrong environment(server side)

I removed two lines and it works with my project