### PR TITLE
Make sure 'fabric' is always global

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -8,7 +8,7 @@ if (typeof exports !== 'undefined') {
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
   fabric.document = document;
   fabric.window = window;
-  // ensure globality even if entire library were function wrapped
+  // ensure globality even if entire library were function wrapped (as in Meteor.js packaging system)
   window.fabric = fabric;
 }
 else {

--- a/HEADER.js
+++ b/HEADER.js
@@ -8,6 +8,8 @@ if (typeof exports !== 'undefined') {
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
   fabric.document = document;
   fabric.window = window;
+  // ensure globality even if entire library were function wrapped
+  window.fabric = fabric;
 }
 else {
   // assume we're running under node.js when document/window are not present


### PR DESCRIPTION
I'm trying to wrap fabric.js as a Meteor.js package (http://atmospherejs.com): `var fabric` become local since the entire library is function wrapped. This is a problem since later code assumes `fabric` is a global symbol.