### PR TITLE
Fix bugs with reflected curve path elements

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -373,9 +373,17 @@
             tempX = current[1];
             tempY = current[2];
 
-            // calculate reflection of previous control points
-            controlX = 2 * x - controlX;
-            controlY = 2 * y - controlY;
+            if (previous[0].match(/[QqTt]/) === null) {
+              // If there is no previous command or if the previous command was not a Q, q, T or t,
+              // assume the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            }
+            else {
+              // calculate reflection of previous control point
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
             ctx.quadraticCurveTo(
               controlX + l,
               controlY + t,

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -357,8 +357,7 @@
             );
             x = tempX;
             y = tempY;
-            controlX = x + current[1];
-            controlY = y + current[2];
+
             break;
 
           case 'T':
@@ -613,8 +612,6 @@
           controlY = 0, // current control point y
           tempX,
           tempY,
-          tempControlX,
-          tempControlY,
           bounds;
 
       for (var i = 0, len = this.path.length; i < len; ++i) {
@@ -709,9 +706,17 @@
             tempX = x + current[3];
             tempY = y + current[4];
 
-            // calculate reflection of previous control points
-            controlX = controlX ? (2 * x - controlX) : x;
-            controlY = controlY ? (2 * y - controlY) : y;
+            if (previous[0].match(/[CcSs]/) === null) {
+              // If there is no previous command or if the previous command was not a C, c, S, or s,
+              // the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            }
+            else {
+              // calculate reflection of previous control points
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
 
             bounds = fabric.util.getBoundsOfCurve(x, y,
               controlX,
@@ -734,9 +739,17 @@
           case 'S': // shorthand cubic bezierCurveTo, absolute
             tempX = current[3];
             tempY = current[4];
-            // calculate reflection of previous control points
-            controlX = 2 * x - controlX;
-            controlY = 2 * y - controlY;
+            if (previous[0].match(/[CcSs]/) === null) {
+              // If there is no previous command or if the previous command was not a C, c, S, or s,
+              // the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            }
+            else {
+              // calculate reflection of previous control points
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
             bounds = fabric.util.getBoundsOfCurve(x, y,
               controlX,
               controlY,
@@ -798,19 +811,11 @@
               controlX = x;
               controlY = y;
             }
-            else if (previous[0] === 't') {
-              // calculate reflection of previous control points for t
-              controlX = 2 * x - tempControlX;
-              controlY = 2 * y - tempControlY;
-            }
-            else if (previous[0] === 'q') {
-              // calculate reflection of previous control points for q
+            else {
+              // calculate reflection of previous control point
               controlX = 2 * x - controlX;
               controlY = 2 * y - controlY;
             }
-
-            tempControlX = controlX;
-            tempControlY = controlY;
 
             bounds = fabric.util.getBoundsOfCurve(x, y,
               controlX,
@@ -828,9 +833,18 @@
           case 'T':
             tempX = current[1];
             tempY = current[2];
-            // calculate reflection of previous control points
-            controlX = 2 * x - controlX;
-            controlY = 2 * y - controlY;
+
+            if (previous[0].match(/[QqTt]/) === null) {
+              // If there is no previous command or if the previous command was not a Q, q, T or t,
+              // assume the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            }
+            else {
+              // calculate reflection of previous control point
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
             bounds = fabric.util.getBoundsOfCurve(x, y,
               controlX,
               controlY,

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -237,7 +237,8 @@
               // the control point is coincident with the current point
               controlX = x;
               controlY = y;
-            } else {
+            }
+            else {
               // calculate reflection of previous control points
               controlX = 2 * x - controlX;
               controlY = 2 * y - controlY;
@@ -270,7 +271,8 @@
               // the control point is coincident with the current point
               controlX = x;
               controlY = y;
-            } else {
+            }
+            else {
               // calculate reflection of previous control points
               controlX = 2 * x - controlX;
               controlY = 2 * y - controlY;

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -234,9 +234,16 @@
             tempX = x + current[3];
             tempY = y + current[4];
 
-            // calculate reflection of previous control points
-            controlX = controlX ? (2 * x - controlX) : x;
-            controlY = controlY ? (2 * y - controlY) : y;
+            if (previous[0].match(/[CcSs]/) === null) {
+              // If there is no previous command or if the previous command was not a C, c, S, or s,
+              // the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            } else {
+              // calculate reflection of previous control points
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
 
             ctx.bezierCurveTo(
               controlX + l,
@@ -260,9 +267,16 @@
           case 'S': // shorthand cubic bezierCurveTo, absolute
             tempX = current[3];
             tempY = current[4];
-            // calculate reflection of previous control points
-            controlX = 2 * x - controlX;
-            controlY = 2 * y - controlY;
+            if (previous[0].match(/[CcSs]/) === null) {
+              // If there is no previous command or if the previous command was not a C, c, S, or s,
+              // the control point is coincident with the current point
+              controlX = x;
+              controlY = y;
+            } else {
+              // calculate reflection of previous control points
+              controlX = 2 * x - controlX;
+              controlY = 2 * y - controlY;
+            }
             ctx.bezierCurveTo(
               controlX + l,
               controlY + t,

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -130,8 +130,6 @@
           controlY = 0, // current control point y
           tempX,
           tempY,
-          tempControlX,
-          tempControlY,
           l = -this.pathOffset.x,
           t = -this.pathOffset.y;
 
@@ -343,19 +341,11 @@
               controlX = x;
               controlY = y;
             }
-            else if (previous[0] === 't') {
-              // calculate reflection of previous control points for t
-              controlX = 2 * x - tempControlX;
-              controlY = 2 * y - tempControlY;
-            }
-            else if (previous[0] === 'q') {
-              // calculate reflection of previous control points for q
+            else {
+              // calculate reflection of previous control point
               controlX = 2 * x - controlX;
               controlY = 2 * y - controlY;
             }
-
-            tempControlX = controlX;
-            tempControlY = controlY;
 
             ctx.quadraticCurveTo(
               controlX + l,
@@ -830,8 +820,7 @@
             );
             x = tempX;
             y = tempY;
-            controlX = x + current[1];
-            controlY = y + current[2];
+
             break;
 
           case 'T':


### PR DESCRIPTION
```xml
<?xml version="1.0"?>
<svg width="420" height="610" viewBox="-10 0 420 610"
     xmlns="http://www.w3.org/2000/svg">

  <path d="M 0,100 l 0,-10 t 0,-40 40,-40 40,40 40,40 40,-40 40,-40 40,40 40,40 40,-40 40,-40 40,40 l 0,50 Z
           M 0,200 l 0,-10 t 0,-40 40,-40 40,40 40,40 40,-40 40,-40 40,40 40,40 40,-40 40,-40 40,40 l 0,50 Z
           M 0,300 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 s 40,0 40,-40 80,-40 80,0 40,40 40,40 q 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,400 l 0,-50 q 0,-40 40,-40 40,0 40,40 s 0,40 40,40 40,-80 80,-80 40,80 80,80 q 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,500 L 0,490 T 0,450 40,410 80,450 120,490 160,450 200,410 240,450 280,490 320,450 360,410 400,450 L 400,500 Z
           M 0,600 L 0,590 Q 0,590 0,550 0,510 40,510 80,510 80,550 80,590 120,590 t 40,-40 40,-40 40,40 40,40 40,-40 40,-40 40,40 l 0,50 Z
        " fill="none" stroke="red" stroke-width="2" />

  <path d="M 0,100 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,200 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,300 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 c 0,0 40,0 40,-40 0,-40 80,-40 80,0 0,40 40,40 40,40 q 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,400 l 0,-50 q 0,-40 40,-40 40,0 40,40 c 0,0 0,40 40,40 40,0 40,-80 80,-80 40,0 40,80 80,80 q 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,500 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
           M 0,600 l 0,-50 q 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 0,40 40,40 40,0 40,-40 0,-40 40,-40 40,0 40,40 l 0,50 Z
        " fill="none" stroke="#ccc" stroke-width="4" />

</svg>
```

As rendered by Chrome:
![svg-chrome](https://cloud.githubusercontent.com/assets/887005/5655889/3d95c03c-969a-11e4-9e2a-86aad0b868bd.png)

As rendered by Fabric.js:
![svg-fabric](https://cloud.githubusercontent.com/assets/887005/5655890/42bfa88e-969a-11e4-950d-4f354918a256.png)

