### PR TITLE
Support HTTPS with different ports not just 443

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -22,7 +22,7 @@
     }
 
     // assign request handler based on protocol
-    var reqHandler = (oURL.protocol.indexOf('https:') ) ? HTTPS : HTTP,
+    var reqHandler = (oURL.protocol.indexOf('https:') === 0 ) ? HTTPS : HTTP,
         req = reqHandler.request({
           hostname: oURL.hostname,
           port: oURL.port,

--- a/src/node.js
+++ b/src/node.js
@@ -22,7 +22,7 @@
     }
 
     // assign request handler based on protocol
-    var reqHandler = ( oURL.port === 443 ) ? HTTPS : HTTP,
+    var reqHandler = (oURL.protocol.indexOf('https:') ) ? HTTPS : HTTP,
         req = reqHandler.request({
           hostname: oURL.hostname,
           port: oURL.port,


### PR DESCRIPTION
We would like to make this change to support HTTPS running on different ports other than 443 since user may have 443 used for something else on their machine. 

Thanks,

Justin