### PR TITLE
Fixes for path-group transformMatrix in svg export

### DIFF
--- a/src/mixins/object.svg_export.js
+++ b/src/mixins/object.svg_export.js
@@ -91,7 +91,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    * @return {String}
    */
   getSvgTransformMatrix: function() {
-    return this.transformMatrix ? ' matrix(' + this.transformMatrix.join(' ') + ')' : '';
+    return this.transformMatrix ? ' matrix(' + this.transformMatrix.join(' ') + ') ' : '';
   },
 
   /**

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -154,7 +154,7 @@
             //jscs:disable validateIndentation
             '<g ',
               'style="', this.getSvgStyles(), '" ',
-              'transform="', translatePart, this.getSvgTransform(), '" ',
+              'transform="', this.getSvgTransformMatrix(), translatePart, this.getSvgTransform(), '" ',
             '>\n'
             //jscs:enable validateIndentation
           ];

--- a/test/unit/path_group.js
+++ b/test/unit/path_group.js
@@ -30,6 +30,16 @@
     'paths':                    getPathObjects()
   };
 
+  var REFERENCE_PATH_GROUP_SVG = '<g style="stroke: none; stroke-width: 1; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(0 0)" >\n' +
+    '<path d="M 100 100 L 300 100 L 200 300 z" style="stroke: blue; stroke-width: 3; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;" transform="" stroke-linecap="round" />\n' +
+    '<path d="M 200 200 L 100 200 L 400 50 z" style="stroke: blue; stroke-width: 3; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;" transform="" stroke-linecap="round" />\n' +
+    '</g>\n';
+
+  var REFERENCE_PATH_GROUP_SVG_WITH_MATRIX = '<g style="stroke: none; stroke-width: 1; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform=" matrix(1 2 3 4 5 6) translate(0 0)" >\n' +
+    '<path d="M 100 100 L 300 100 L 200 300 z" style="stroke: blue; stroke-width: 3; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;" transform="" stroke-linecap="round" />\n' +
+    '<path d="M 200 200 L 100 200 L 400 50 z" style="stroke: blue; stroke-width: 3; stroke-dasharray: ; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;" transform="" stroke-linecap="round" />\n' +
+    '</g>\n';
+
   function getPathElement(path) {
     var el = fabric.document.createElement('path');
     el.setAttribute('d', path);
@@ -218,6 +228,17 @@
       pathGroup.set('left', 1234);
       ok(pathGroup.getObjects()[0].get('left') !== 1234);
       equal(pathGroup.get('left'), 1234);
+      start();
+    });
+  });
+  
+  asyncTest('toSVG', function() {
+    ok(fabric.PathGroup);
+    getPathGroupObject(function(pathGroup) {
+      ok(typeof pathGroup.toSVG == 'function');
+      equal(pathGroup.toSVG(), REFERENCE_PATH_GROUP_SVG);
+      pathGroup.transformMatrix = [1, 2, 3, 4, 5, 6];
+      equal(pathGroup.toSVG(), REFERENCE_PATH_GROUP_SVG_WITH_MATRIX);
       start();
     });
   });


### PR DESCRIPTION
solves missing transformMatrix, fixing it for normal groups will be harder in my opinion.

canvas
![image](https://cloud.githubusercontent.com/assets/1194048/5934373/c5a4904a-a6ce-11e4-82cf-0b3d474992b7.png)

SVG
![image](https://cloud.githubusercontent.com/assets/1194048/5934376/ce580bfe-a6ce-11e4-9213-9415d29fe420.png)

close #1808
closes #1808