### PR TITLE
Extend iText to accept accents

### DIFF
--- a/src/mixins/accented_text.js
+++ b/src/mixins/accented_text.js
@@ -1,0 +1,50 @@
+function accentedTextCreator() {
+    return fabric.util.createClass(fabric.IText, {
+        initHiddenTextarea: function() {
+            this.hiddenTextarea = fabric.document.createElement('textarea');
+
+            this.hiddenTextarea.setAttribute('autocapitalize', 'off');
+            this.hiddenTextarea.setAttribute('wrap', 'off');
+            this.hiddenTextarea.setAttribute('rows', '6');
+            this.hiddenTextarea.style.cssText = 'position: absolute; top: 0; left: -9999px';
+
+            fabric.document.body.appendChild(this.hiddenTextarea);
+
+            fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
+            fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));
+
+            if (!this._clickHandlerInitialized && this.canvas) {
+                fabric.util.addListener(this.canvas.upperCanvasEl, 'click', this.onClick.bind(
+                    this));
+                this._clickHandlerInitialized = true;
+            }
+        },
+
+        onInput: function(e) {
+            var cp = this.hiddenTextarea.selectionStart || 0;
+            this.text = '';
+            this.insertChars(e.srcElement.value);
+            this.selectionStart = this.selectionEnd = cp;
+        },
+
+        onKeyDown: function(e) {
+            if (!this.isEditing) return;
+
+            var me = this;
+            setTimeout(function() {
+                me.selectionStart = me.hiddenTextarea.selectionStart;
+                me.selectionEnd = me.hiddenTextarea.selectionEnd;
+            }, 0);
+
+            //Ctrl + a
+            if ((e.keyCode == 65) && (e.ctrlKey || e.metaKey)) {
+                this.hiddenTextarea.selectionStart = 0;
+                this.hiddenTextarea.selectionEnd = this.text.length;
+            }
+
+            e.stopPropagation();
+
+            this.canvas && this.canvas.renderAll();
+        },
+    });
+}


### PR DESCRIPTION
I'm accepting accents on fabric using this js I made.
It's another aproach for the same problem https://github.com/kangax/fabric.js/pull/1625.

Since itext is on heavy restyling, I hope you can find this useful.

It's not connected as a plugin yet.
Works only importing the new js and creating accentedTextCreator instead of iText.
Instead of: new fabric.IText(...
Do: new accentedTextCreator()(...

Change-Id: I31df92b058c0d8a7af6209618bcecfb99f4d2306