### PR TITLE
Fixes svg rendering rules

### DIFF
--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -228,7 +228,7 @@
    * @private
    */
   function isValidRadius(attributes) {
-    return (('radius' in attributes) && (attributes.radius > 0));
+    return (('radius' in attributes) && (attributes.radius >= 0));
   }
   /* _FROM_SVG_END_ */
 

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -57,7 +57,7 @@
      */
     initialize: function(points, options) {
       options = options || { };
-      this.points = points;
+      this.points = points || [ ];
       this.callSuper('initialize', options);
       this._calcDimensions();
       if (!('top' in options)) {
@@ -79,11 +79,11 @@
           maxX = max(points, 'x'),
           maxY = max(points, 'y');
 
-      this.width = (maxX - minX) || 1;
-      this.height = (maxY - minY) || 1;
+      this.width = (maxX - minX) || 0;
+      this.height = (maxY - minY) || 0;
 
-      this.minX = minX,
-      this.minY = minY;
+      this.minX = minX || 0,
+      this.minY = minY || 0;
     },
 
     /**
@@ -141,7 +141,9 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-      this.commonRender(ctx);
+      if(!this.commonRender(ctx)) {
+        return;
+      }
       this._renderFill(ctx);
       if (this.stroke || this.strokeDashArray) {
         ctx.closePath();
@@ -154,7 +156,14 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     commonRender: function(ctx) {
-      var point;
+      var point, len = this.points.length;
+
+      if (!len || isNaN(this.points[len - 1].y)) {
+        // do not draw if no points or odd points
+        // NaN comes from parseFloat of a empty string in parser
+        return false;
+      }
+
       ctx.beginPath();
 
       if (this._applyPointOffset) {
@@ -165,10 +174,11 @@
       }
 
       ctx.moveTo(this.points[0].x, this.points[0].y);
-      for (var i = 0, len = this.points.length; i < len; i++) {
+      for (var i = 0; i < len; i++) {
         point = this.points[i];
         ctx.lineTo(point.x, point.y);
       }
+      return true;
     },
 
     /**
@@ -215,10 +225,6 @@
 
     var points = fabric.parsePointsAttribute(element.getAttribute('points')),
         parsedAttributes = fabric.parseAttributes(element, fabric.Polygon.ATTRIBUTE_NAMES);
-
-    if (points === null) {
-      return null;
-    }
 
     return new fabric.Polygon(points, extend(parsedAttributes, options));
   };

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -141,7 +141,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-      if(!this.commonRender(ctx)) {
+      if (!this.commonRender(ctx)) {
         return;
       }
       this._renderFill(ctx);

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -108,7 +108,9 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-      fabric.Polygon.prototype.commonRender.call(this, ctx);
+      if(!fabric.Polygon.prototype.commonRender.call(this, ctx)) {
+        return;
+      }
       this._renderFill(ctx);
       this._renderStroke(ctx);
     },
@@ -162,10 +164,6 @@
 
     var points = fabric.parsePointsAttribute(element.getAttribute('points')),
         parsedAttributes = fabric.parseAttributes(element, fabric.Polyline.ATTRIBUTE_NAMES);
-
-    if (points === null) {
-      return null;
-    }
 
     return new fabric.Polyline(points, fabric.util.object.extend(parsedAttributes, options));
   };

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -108,7 +108,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-      if(!fabric.Polygon.prototype.commonRender.call(this, ctx)) {
+      if (!fabric.Polygon.prototype.commonRender.call(this, ctx)) {
         return;
       }
       this._renderFill(ctx);

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -221,8 +221,9 @@
 
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
-
-    return new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
+    var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
+    rect.visible = rect.width > 0 && rect.height > 0;
+    return rect;
   };
   /* _FROM_SVG_END_ */
 

--- a/test/unit/polygon.js
+++ b/test/unit/polygon.js
@@ -37,6 +37,14 @@
     'globalCompositeOperation': 'source-over'
   };
 
+  var REFERENCE_EMPTY_OBJECT = {
+    'points': [],
+    'width': 0,
+    'height': 0,
+    'top': 0,
+    'left': 0
+  };
+
   QUnit.module('fabric.Polygon');
 
   test('constructor', function() {
@@ -76,6 +84,18 @@
 
   test('fromElement', function() {
     ok(typeof fabric.Polygon.fromElement == 'function');
+
+    var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
+    empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+
+    var elPolygonWithoutPoints = fabric.document.createElement('polygon');
+
+    deepEqual(fabric.Polygon.fromElement(elPolygonWithoutPoints).toObject(), empty_object);
+
+    var elPolygonWithEmptyPoints = fabric.document.createElement('polygon');
+    elPolygonWithEmptyPoints.setAttribute('points', '');
+
+    deepEqual(fabric.Polygon.fromElement(elPolygonWithEmptyPoints).toObject(), empty_object);
 
     var elPolygon = fabric.document.createElement('polygon');
 
@@ -129,15 +149,6 @@
     }));
 
     deepEqual(polygonWithAttrs.get('transformMatrix'), [ 2, 0, 0, 2, -10, -20 ]);
-
-    var elPolygonWithoutPoints = fabric.document.createElement('polygon');
-
-    equal(fabric.Polygon.fromElement(elPolygonWithoutPoints), null);
-
-    var elPolygonWithEmptyPoints = fabric.document.createElement('polygon');
-    elPolygonWithEmptyPoints.setAttribute('points', '');
-
-    equal(fabric.Polygon.fromElement(elPolygonWithEmptyPoints), null);
 
     equal(fabric.Polygon.fromElement(), null);
   });

--- a/test/unit/polyline.js
+++ b/test/unit/polyline.js
@@ -37,6 +37,14 @@
     'globalCompositeOperation': 'source-over'
   };
 
+  var REFERENCE_EMPTY_OBJECT = {
+    'points': [],
+    'width': 0,
+    'height': 0,
+    'top': 0,
+    'left': 0
+  };
+
   QUnit.module('fabric.Polyline');
 
   test('constructor', function() {
@@ -75,6 +83,17 @@
 
   test('fromElement', function() {
     ok(typeof fabric.Polyline.fromElement == 'function');
+
+    var elPolylineWithoutPoints = fabric.document.createElement('polyline');
+    var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
+    empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+
+    deepEqual(fabric.Polyline.fromElement(elPolylineWithoutPoints).toObject(), empty_object);
+
+    var elPolylineWithEmptyPoints = fabric.document.createElement('polyline');
+    elPolylineWithEmptyPoints.setAttribute('points', '');
+
+    deepEqual(fabric.Polyline.fromElement(elPolylineWithEmptyPoints).toObject(), empty_object);
 
     var elPolyline = fabric.document.createElement('polyline');
 
@@ -118,14 +137,6 @@
     }));
 
     deepEqual(polylineWithAttrs.get('transformMatrix'), [ 2, 0, 0, 2, -10, -20 ]);
-
-    var elPolylineWithoutPoints = fabric.document.createElement('polyline');
-    equal(fabric.Polyline.fromElement(elPolylineWithoutPoints), null);
-
-    var elPolylineWithEmptyPoints = fabric.document.createElement('polyline');
-    elPolylineWithEmptyPoints.setAttribute('points', '');
-
-    equal(fabric.Polyline.fromElement(elPolylineWithEmptyPoints), null);
 
     equal(fabric.Polyline.fromElement(), null);    
   });

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -71,9 +71,10 @@
 
     var elRect = fabric.document.createElement('rect');
     var rect = fabric.Rect.fromElement(elRect);
-
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.visible = false;
     ok(rect instanceof fabric.Rect);
-    deepEqual(rect.toObject(), REFERENCE_RECT);
+    deepEqual(rect.toObject(), expectedObject);
   });
 
   test('fabric.Rect.fromElement with custom attributes', function() {


### PR DESCRIPTION
This PR fixes some bugs of svg import:

Circle class:
Radius equal 0 is not an error, but the circle should not be rendered ( this is handled with normal if object.width and object.height both equal 0 early return from rendering );

Polygon and polyline, empty point should not give empty object, just not rendered object.
Same for odd point number. Firefox and chrome are rendering it, but they should not.

Rect: whilec canvas draw a 0 width OR 0 height stroke rectangle, svg says not. So simply set visible equal false to rect coming from svg elements with width or height equal to 0.

Those SVG where previously not rendered in fabric and were throwing errors.

![image](https://cloud.githubusercontent.com/assets/1194048/6011116/da48347a-ab38-11e4-8487-8f57ae946c23.png)

Rendering by browsers:
![image](https://cloud.githubusercontent.com/assets/1194048/6011134/f8a2dea2-ab38-11e4-9622-cee8e2645b72.png)

![image](https://cloud.githubusercontent.com/assets/1194048/6011137/fed932bc-ab38-11e4-8cba-61097f1a555e.png)

![image](https://cloud.githubusercontent.com/assets/1194048/6011143/0742be28-ab39-11e4-86c7-2297052070f0.png)

![image](https://cloud.githubusercontent.com/assets/1194048/6011152/110645d8-ab39-11e4-902d-4c76fa52d19b.png)

