### PR TITLE
Add forcedfocus on enterEditing

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -327,6 +327,7 @@
       this.isEditing = true;
 
       this.initHiddenTextarea();
+      this.hiddenTextarea.focus();
       this._updateTextarea();
       this._saveEditingProps();
       this._setEditingProps();

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -15,11 +15,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     fabric.util.addListener(this.hiddenTextarea, 'keypress', this.onKeyPress.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'copy', this.copy.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'paste', this.paste.bind(this));
-
-    if (!this._clickHandlerInitialized && this.canvas) {
-      fabric.util.addListener(this.canvas.upperCanvasEl, 'click', this.onClick.bind(this));
-      this._clickHandlerInitialized = true;
-    }
   },
 
   /**
@@ -47,11 +42,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   _ctrlKeysMap: {
     65: 'selectAll',
     88: 'cut'
-  },
-
-  onClick: function() {
-    // No need to trigger click event here, focus is enough to have the keyboard appear on Android
-    this.hiddenTextarea && this.hiddenTextarea.focus();
   },
 
   /**


### PR DESCRIPTION
As per #1740 discussion we force focus to mimic click on object

Someone should test if the android hack for onclcik event is removable.

close 1740#