### PR TITLE
Fix issue #726

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -501,8 +501,16 @@
       var target = transform.target, forbidScalingX = false, forbidScalingY = false,
           strokeWidth = target.stroke ? target.strokeWidth : 0;
 
-      transform.newScaleX = localMouse.x / (target.width + strokeWidth / 2);
-      transform.newScaleY = localMouse.y / (target.height + strokeWidth / 2);
+      if (target.type == 'rect' || target.type == 'triangle' || target.type == 'text' || target.type == 'line'){
+        transform.newScaleX = localMouse.x / 
+          ((target.width + Math.abs(target.height*target.transformMatrix[2]))+ strokeWidth / 2);
+        transform.newScaleY = localMouse.y / 
+          ((target.height + Math.abs(target.width*target.transformMatrix[1])) + strokeWidth / 2);
+        }
+      else {
+        transform.newScaleX = localMouse.x / (target.width + strokeWidth / 2);
+        transform.newScaleY = localMouse.y / (target.height + strokeWidth / 2);
+        }
 
       if (lockScalingFlip && transform.newScaleX <= 0 && transform.newScaleX < target.scaleX) {
         forbidScalingX = true;
@@ -513,7 +521,13 @@
       }
 
       if (by === 'equally' && !lockScalingX && !lockScalingY) {
-        forbidScalingX || forbidScalingY || this._scaleObjectEqually(localMouse, target, transform);
+        if (target.type == 'rect' || target.type == 'triangle' || target.type == 'text' || target.type == 'line'){
+          forbidScalingX || forbidScalingY || 
+          target.set('scaleX', transform.newScaleX),target.set('scaleY', transform.newScaleY);
+          }
+        else {    
+          forbidScalingX || forbidScalingY || this._scaleObjectEqually(localMouse, target, transform);
+          }
       }
       else if (!by) {
         forbidScalingX || lockScalingX || target.set('scaleX', transform.newScaleX);

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -222,7 +222,13 @@
      * @return {Number} width value
      */
     getWidth: function() {
-      return this.width * this.scaleX;
+      if ((this.type == 'rect' || this.type == 'triangle' || this.type == 'text' || this.type == 'line') &&
+      (this.transformMatrix[1] != 0 || this.transformMatrix[2] != 0)){
+        return this.width * this.scaleX + Math.abs(this.height * this.transformMatrix[2])*this.scaleX;
+        }
+      else {
+        return this.width * this.scaleX;
+        }
     },
 
     /**
@@ -230,7 +236,13 @@
      * @return {Number} height value
      */
     getHeight: function() {
-      return this.height * this.scaleY;
+      if ((this.type == 'rect' || this.type == 'triangle' || this.type == 'text' || this.type == 'line') &&
+      (this.transformMatrix[1] != 0 || this.transformMatrix[2] != 0)){
+        return this.height * this.scaleY + Math.abs(this.width * this.transformMatrix[1])*this.scaleY;
+        }
+      else {
+        return this.height * this.scaleY;
+        }
     },
 
     /**

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -131,8 +131,18 @@
         h += (h < 0 ? -strokeWidth : strokeWidth);
       }
 
-      w = w * this.scaleX + 2 * this.padding;
-      h = h * this.scaleY + 2 * this.padding;
+      if ((this.type == 'rect' || this.type == 'triangle' || this.type == 'text' || this.type == 'line') && 
+      (this.transformMatrix[1] != 0 || this.transformMatrix[2] != 0)){
+      //TODO better _calculateCurrentDimensions if strokeWidth != 0 
+        var currentWidth = (w * this.scaleX + Math.abs(h*this.transformMatrix[2])*this.scaleX + 2 * this.padding);
+        var currentHeight = (h * this.scaleY + Math.abs(w*this.transformMatrix[1])*this.scaleY + 2 * this.padding);
+        }
+      else {
+        var currentWidth = w * this.scaleX + 2 * this.padding;
+        var currentHeight = h * this.scaleY + 2 * this.padding;
+        }
+      w = currentWidth;
+      h = currentHeight;
 
       if (shouldTransform) {
         return fabric.util.transformPoint(new fabric.Point(w, h), vpt, true);

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -1,5 +1,5 @@
 (function(global) {
-
+//TODO private getHeight(): and getWidth(): for support skew
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { }),
@@ -55,6 +55,7 @@
      */
     y2: 0,
 
+    transformMatrix: [1,0,0,1,0,0],
     /**
      * Constructor
      * @param {Array} [points] Array of points

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -1,5 +1,5 @@
 (function(global) {
-
+//TODO private getHeight(): and getWidth(): for support skew
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { }),
@@ -49,6 +49,8 @@
      * @default
      */
     ry:   0,
+    
+    transformMatrix: [1,0,0,1,0,0],
 
     /**
      * Used to specify dash pattern for stroke on this object

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1,5 +1,5 @@
 (function(global) {
-
+//TODO private getHeight(): and getWidth(): for support skew
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { }),
@@ -288,6 +288,8 @@
      * @default
      */
     shadow:               null,
+    
+    transformMatrix:     [1,0,0,1,0,0],
 
     /**
      * @private

--- a/src/shapes/triangle.class.js
+++ b/src/shapes/triangle.class.js
@@ -1,5 +1,5 @@
 (function(global) {
-
+//TODO private getHeight(): and getWidth(): for support skew
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { });
@@ -24,6 +24,8 @@
      * @default
      */
     type: 'triangle',
+    
+    transformMatrix: [1,0,0,1,0,0],
 
     /**
      * Constructor

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -552,7 +552,228 @@
       imageData = null;
 
       return _isTransparent;
+    },
+    
+  /*Take a visible object and skewing this one.
+  * inclination = [skewX, skewY].
+  */
+  skewObject: function(inclination, object) {
+  //TODO function that change the originX and originY of the generic object in 'left' and 'top' rispectively.
+    var canvas = object.canvas;
+    object.transformMatrix = [1,inclination[1],inclination[0],1,0,0];
+    if (object.type == 'path') {
+      var newPath = new fabric.Path(fabric.util.pathToNewPath(object.path, inclination[0], inclination[1]));
+      object.width = newPath.width;
+      object.height = newPath.height;
+      canvas.renderAll();
+      object.setCoords();
+      }
+    else if (object.type == 'circle') {
+      var newDimension = fabric.util.skewCircleWidthHeight(object, inclination);
+      object.width = newDimension.width;
+      object.height = newDimension.height;
+      canvas.renderAll();
+      object.setCoords();
+      }
+    else if (object.type == 'ellipse') {
+      var newDimension = fabric.util.skewEllipseWidthHeight(object, inclination);
+      object.width = newDimension.width;
+      object.height = newDimension.height;
+      canvas.renderAll();
+      object.setCoords();
+      }
+    else if (object.type == 'rect' || object.type == 'triangle' || object.type == 'text' || object.type == 'line') {
+      canvas.renderAll();
+      object.setCoords();
+      }
+    else if (object.type == 'polygon' || object.type == 'polyline') {
+      object.transformMatrix = [1,0,0,1,0,0];
+      var getAbsoluteCoords = fabric.util.getAbsoluteCoords;
+      var skewPolygonPoints = fabric.util.skewPolygonPoints;
+      var changePolygonProp = fabric.util.changePolygonProp;
+      var active = object.active;
+      if (!object.notSkewed){
+        object.notSkewed = new fabric.Polygon(getAbsoluteCoords(object, skewPolygonPoints(object.points, [0,0])));
+        canvas.add(object.notSkewed);      //Set the the not skewed polygon's absolute coords,
+        canvas.remove(object.notSkewed);   //maybe(of course) there is a better way!
+        }
+      else {
+        object.notSkewed.top = object.top;
+        object.notSkewed.left = object.left;
+        changePolygonProp(object, object.notSkewed);
+        }
+      var newPol = new fabric.Polygon(getAbsoluteCoords(object, skewPolygonPoints(object.points, inclination)));
+      changePolygonProp(object, newPol);
+      canvas.remove(object);
+      canvas.add(object);
+      if (active) {
+        canvas.setActiveObject(object);
+        }
     }
+  },
+     
+     /*
+     * Private
+     */
+     pathToNewPath: function(path, skewX, skewY){
+       var newPath = '';
+       var lastX;
+       var lastY;
+       for (var i in path){
+         if (path[i][0] == 'M'){
+           newPath += 'M ';
+           var newX = lastX = path[i][1] + path[i][2]*skewX;
+           var newY = lastY = path[i][2] + path[i][1]*skewY;
+           newPath += newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'L'){
+           newPath += 'L ';
+           var newX = lastX = path[i][1] + path[i][2]*skewX;
+           var newY = lastY = path[i][2] + path[i][1]*skewY;
+           newPath += newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'H'){
+           newPath += 'H '
+           var newX = lastX = path[i][1] + lastY*skewX;
+           newPath += newX.toString() + ' ';
+           }
+         if (path[i][0] == 'V'){
+           newPath += 'V ';
+           var newY = lastY = path[i][1] + lastX*skewY;
+           newPath += newY.toString() + ' ';
+           }
+         if (path[i][0] == 'C'){
+           newPath += 'C ';
+           newControlX1 = path[i][1] + path[i][2]*skewX;
+           newControlY1 = path[i][2] + path[i][1]*skewY;
+           newControlX2 = path[i][3] + path[i][4]*skewX;
+           newControlY2 = path[i][4] + path[i][3]*skewY;
+           newX = lastX = path[i][5] + path[i][6]*skewX;
+           newY = lastY = path[i][6] + path[i][5]*skewY;
+           newPath += newControlX1.toString() + ' ' + newControlY1.toString() + ' ' +
+             newControlX2.toString() + ' ' + newControlY2.toString() + ' ' +
+             newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'S'){
+           newPath += 'S ';
+           newControlX1 = path[i][1] + path[i][2]*skewX;
+           newControlY1 = path[i][2] + path[i][1]*skewY;
+           newX = lastX = path[i][3] + path[i][4]*skewX;
+           newY = lastY = path[i][4] + path[i][3]*skewY;
+           newPath += newControlX1.toString() + ' ' + newControlY1.toString() + ' ' +
+             newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'Q'){
+           newPath += 'Q ';
+           newControlX1 = path[i][1] + path[i][2]*skewX;
+           newControlY1 = path[i][2] + path[i][1]*skewY;
+           newX = lastX = path[i][3] + path[i][4]*skewX;
+           newY = lastY = path[i][4] + path[i][3]*skewY;
+           newPath += newControlX1.toString() + ' ' + newControlY1.toString() + ' ' +
+             newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'T'){
+           newPath += 'T ';
+           var newX = lastX = path[i][1] + path[i][2]*skewX;
+           var newY = lastY = path[i][2] + path[i][1]*skewY;
+           newPath += newX.toString() + ' ' + newY.toString() + ' ';
+           }
+         if (path[i][0] == 'A'){
+         //TODO arc
+           }
+         if (path[i][0] == 'Z'){
+           newPath += 'Z ';
+           }
+         }
+    return newPath;
+    },
+    
+    /*
+    * Private
+    */
+    skewCircleWidthHeight: function(object, inclination) {
+      var centerX = object.getCenterPoint().x;
+      var centerY = object.getCenterPoint().y;
+      var radius = object.radius + object.strokeWidth/2;
+      var skewX = inclination[0];
+      var skewY = inclination[1];
+      var tx1 = Math.atan(inclination[0]);
+      var tx2 = tx1 + Math.PI;
+      var ty1 = 1.5707963267948966 - Math.atan(inclination[1]); // This is equal to arccot(x)
+      var ty2 = ty1 + Math.PI;
+      var coordX1 = centerX + radius*Math.cos(tx1) + (centerY + radius*Math.sin(tx1))*skewX;
+      var coordX2 = centerX + radius*Math.cos(tx2) + (centerY + radius*Math.sin(tx2))*skewX;
+      var coordY1 = centerY + radius*Math.sin(ty1) + (centerX + radius*Math.cos(ty1))*skewY;
+      var coordY2 = centerY + radius*Math.sin(ty2) + (centerX + radius*Math.cos(ty2))*skewY;
+      var newWidth = Math.abs(coordX1 - coordX2);
+      var newHeight = Math.abs(coordY1 - coordY2);
+      return {width: newWidth, height: newHeight};
+    },
+
+    /*
+    * Private
+    */    
+    skewEllipseWidthHeight: function(object, inclination){
+      var a = (object.rx) + object.strokeWidth/2;
+      var b = (object.ry) + object.strokeWidth/2;
+      var skewX = inclination[0];
+      var skewY = inclination[1];
+      var tx1 = Math.atan(b*skewX / a);
+      var tx2 = tx1 + Math.PI;
+      var ty1 = 1.5707963267948966 - Math.atan(b / a*skewY); // This is equal to arccot(x)
+      var ty2 = ty1 + Math.PI;
+      var coordX1 = a*Math.cos(tx1) + b*Math.sin(tx1)*skewX;
+      var coordX2 = a*Math.cos(tx2) + b*Math.sin(tx2)*skewX;
+      var coordY1 = b*Math.sin(ty1) + a*Math.cos(ty1)*skewY;
+      var coordY2 = b*Math.sin(ty2) + a*Math.cos(ty2)*skewY;
+      var newWidth = Math.abs(coordX1 - coordX2);
+      var newHeight = Math.abs(coordY1 - coordY2);
+      return {width: newWidth, height: newHeight};
+    },
+    
+    /*
+    * Private
+    */    
+    getAbsoluteCoords: function(object, points) {
+      var center = object.getCenterPoint();
+      var newPoints = [];
+      for (var index in points) {
+        var thisPoint = points[index];
+        var newX = thisPoint.x + center.x;
+        var newY = thisPoint.y + center.y;
+        newPoints.push({x: newX, y: newY});
+        }
+      return newPoints;
+    },
+    
+    /*
+    * Private
+    */    
+    skewPolygonPoints: function(points, inclination) {
+      var skewX = inclination[0];
+      var skewY = inclination[1];
+      var newPoints = [];
+      for (var index in points) {
+        var point = points[index];
+        var newX = point.x + point.y*skewX;
+        var newY = point.y + point.x*skewY;
+        newPoints.push({x: newX, y: newY});
+        }
+      return newPoints;
+    },
+    
+    /*
+    * Private
+    */    
+    changePolygonProp: function(object1, object2, options){
+      if (!options){
+        var options = ['_applyPointOffset', '_prevGlobalCompositeOperation',
+          'width', 'height', 'minX', 'minY', 'points'];
+        }
+      for (var index in options){
+        object1[options[index]] = object2[options[index]];
+        }
+    },
   };
 
 })(typeof exports !== 'undefined' ? exports : this);


### PR DESCRIPTION
Add to fabric.util{} skewObject that take inclination = [skewX,skewY] and the object that I want skewing.

Add to fabric.util{} pathToNewPath, skewCircleWidthHeight, skewEllipseWidthHeight, getAbsoluteCoords, skewPolygonPoints, changePolygonProp.

Change getHeight, getWidth, drawControls, setCoords, _setObjectScale for support rect, text, line, triangle, skewed.

Now skewing work not bad for circle ellipse path polygon polyline and rect, skew work worse for text, line, triangle for the latters see the new TODO.

For skewing one object this one must have originX = top and originY = left.

If rect, line, text, triangle are skewing _scaleObjectEqually isn't supported.

There are little problems with rect, line, text, triangle that are skewing if strokeWidth != 0.
Not very well tested.

modified:   src/canvas.class.js
modified:   src/mixins/object_geometry.mixin.js
modified:   src/mixins/object_interactivity.mixin.js
modified:   src/shapes/line.class.js
modified:   src/shapes/rect.class.js
modified:   src/shapes/text.class.js
modified:   src/shapes/triangle.class.js
modified:   src/util/misc.js