### PR TITLE
Fix aligning guidelines on zoom

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -64,8 +64,8 @@ function initAligningGuidelines(canvas) {
         activeObjectCenter = activeObject.getCenterPoint(),
         activeObjectLeft = activeObjectCenter.x,
         activeObjectTop = activeObjectCenter.y,
-        activeObjectHeight = activeObject.getBoundingRectHeight(),
-        activeObjectWidth = activeObject.getBoundingRectWidth(),
+        activeObjectHeight = activeObject.getBoundingRectHeight() / viewportTransform[3],
+        activeObjectWidth = activeObject.getBoundingRectWidth() / viewportTransform[0],
         horizontalInTheRange = false,
         verticalInTheRange = false,
         transform = canvas._currentTransform;
@@ -82,8 +82,8 @@ function initAligningGuidelines(canvas) {
       var objectCenter = canvasObjects[i].getCenterPoint(),
           objectLeft = objectCenter.x,
           objectTop = objectCenter.y,
-          objectHeight = canvasObjects[i].getBoundingRectHeight(),
-          objectWidth = canvasObjects[i].getBoundingRectWidth();
+          objectHeight = canvasObjects[i].getBoundingRectHeight() / viewportTransform[3],
+          objectWidth = canvasObjects[i].getBoundingRectWidth() / viewportTransform[0];
 
       // snap by the horizontal center line
       if (isInRange(objectLeft, activeObjectLeft)) {
@@ -196,7 +196,7 @@ function initAligningGuidelines(canvas) {
     for (var i = horizontalLines.length; i--; ) {
       drawHorizontalLine(horizontalLines[i]);
     }
-    
+
     verticalLines.length = horizontalLines.length = 0;
   });
 


### PR DESCRIPTION
Aligning guidelines are not displayed at the correct position when canvas is zoomed. This pull request fixes it.