### PR TITLE
Fix base throwing error when strokeDashArray unitialized

### DIFF
--- a/src/brushes/base_brush.class.js
+++ b/src/brushes/base_brush.class.js
@@ -71,7 +71,9 @@ fabric.BaseBrush = fabric.util.createClass(/** @lends fabric.BaseBrush.prototype
     ctx.lineWidth = this.width;
     ctx.lineCap = this.strokeLineCap;
     ctx.lineJoin = this.strokeLineJoin;
-    ctx.setLineDash(this.strokeDashArray);
+    if (this.strokeDashArray) {
+      ctx.setLineDash(this.strokeDashArray);
+    }
   },
 
   /**


### PR DESCRIPTION
Other places in the codebase guard the call to ctx.setLineDash,
so this should happen here too. Fixes https://github.com/kangax/fabric.js/issues/1986.