### PR TITLE
Fixed race condition in the iText cursor flash animation

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -61,10 +61,13 @@
      * @private
      */
     _tick: function() {
-      if (this._abortCursorAnimation) {
-        return;
-      }
 
+      var tickState = {
+        isAborted: false,
+        abort: function(){
+          this.isAborted = true;
+        },
+      };
       var _this = this;
 
       this.animate('_currentCursorOpacity', 1, {
@@ -72,7 +75,8 @@
         duration: this.cursorDuration,
 
         onComplete: function() {
-          _this._onTickComplete();
+          if (!tickState.isAborted)
+            _this._onTickComplete();
         },
 
         onChange: function() {
@@ -80,20 +84,25 @@
         },
 
         abort: function() {
-          return _this._abortCursorAnimation;
+          return tickState.isAborted;
         }
       });
+
+      this._currentTickState = tickState;
     },
 
     /**
      * @private
      */
     _onTickComplete: function() {
-      if (this._abortCursorAnimation) {
-        return;
-      }
 
       var _this = this;
+      var tickState = {
+        isAborted: false,
+        abort: function(){
+          this.isAborted = true;
+        },
+      };
       if (this._cursorTimeout1) {
         clearTimeout(this._cursorTimeout1);
       }
@@ -101,16 +110,19 @@
         _this.animate('_currentCursorOpacity', 0, {
           duration: this.cursorDuration / 2,
           onComplete: function() {
-            _this._tick();
+            if (!tickState.isAborted)
+              _this._tick();
           },
           onChange: function() {
             _this.canvas && _this.canvas.renderAll();
           },
           abort: function() {
-            return _this._abortCursorAnimation;
+            return tickState.isAborted;
           }
         });
       }, 100);
+
+      this._currentTickCompleteState = tickState;
     },
 
     /**
@@ -121,7 +133,8 @@
           delay = restart ? 0 : this.cursorDelay;
 
       if (restart) {
-        this._abortCursorAnimation = true;
+        this._currentTickState && this._currentTickState.abort();
+        this._currentTickCompleteState && this._currentTickCompleteState.abort();
         clearTimeout(this._cursorTimeout1);
         this._currentCursorOpacity = 1;
         this.canvas && this.canvas.renderAll();
@@ -130,7 +143,6 @@
         clearTimeout(this._cursorTimeout2);
       }
       this._cursorTimeout2 = setTimeout(function() {
-        _this._abortCursorAnimation = false;
         _this._tick();
       }, delay);
     },
@@ -139,18 +151,14 @@
      * Aborts cursor animation and clears all timeouts
      */
     abortCursorAnimation: function() {
-      this._abortCursorAnimation = true;
+      this._currentTickState && this._currentTickState.abort();
+      this._currentTickCompleteState && this._currentTickCompleteState.abort();
 
       clearTimeout(this._cursorTimeout1);
       clearTimeout(this._cursorTimeout2);
 
       this._currentCursorOpacity = 0;
       this.canvas && this.canvas.renderAll();
-
-      var _this = this;
-      setTimeout(function() {
-        _this._abortCursorAnimation = false;
-      }, 10);
     },
 
     /**

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -62,21 +62,22 @@
      */
     _tick: function() {
 
-      var tickState = {
+      var tickState, _this = this;
+      tickState = {
         isAborted: false,
-        abort: function(){
+        abort: function() {
           this.isAborted = true;
         },
       };
-      var _this = this;
 
       this.animate('_currentCursorOpacity', 1, {
 
         duration: this.cursorDuration,
 
         onComplete: function() {
-          if (!tickState.isAborted)
+          if (!tickState.isAborted) {
             _this._onTickComplete();
+          }
         },
 
         onChange: function() {
@@ -96,10 +97,10 @@
      */
     _onTickComplete: function() {
 
-      var _this = this;
-      var tickState = {
+      var tickState, _this = this;
+      tickState = {
         isAborted: false,
-        abort: function(){
+        abort: function() {
           this.isAborted = true;
         },
       };
@@ -110,8 +111,9 @@
         _this.animate('_currentCursorOpacity', 0, {
           duration: this.cursorDuration / 2,
           onComplete: function() {
-            if (!tickState.isAborted)
+            if (!tickState.isAborted) {
               _this._tick();
+            }
           },
           onChange: function() {
             _this.canvas && _this.canvas.renderAll();


### PR DESCRIPTION
The animation that flashes the iText cursor can race its own
cancellation, meaning that you can have two _tick()'s and two
_tickComplete() animations at the same time. On iOS in particular,
most likely due to the lower frequency of timeouts, this can trap
the cursor in a state where its opacity is always <0.1 and is
essentially invisible.

This PR captures the abort state of _tick in such a way that
one can abort the existing _tick and then immediately call _tick()
again safely.