### PR TITLE
Improve the way the IText hidden textarea is positioned.

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -18,10 +18,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       var updateHiddenTextareaPosition = function () {
         if (this.isEditing && this.canvas.getActiveObject() === this) {
           //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
-          var rect = this.getBoundingRect();
+          var rect = this.getBoundingRect(),
 
           // Compute the scale transform between fabric coords and DOM coords
-          var canvasRect = this.canvas.lowerCanvasEl.getBoundingClientRect(),
+            canvasRect = this.canvas.lowerCanvasEl.getBoundingClientRect(),
             xScale = canvasRect.width / this.canvas.width,
             yScale = canvasRect.height / this.canvas.height;
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -19,10 +19,16 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         if (this.isEditing && this.canvas.getActiveObject() === this) {
           //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
           var rect = this.getBoundingRect();
-          this.hiddenTextarea.style.top = rect.top + 'px';
-          this.hiddenTextarea.style.left = rect.left + 'px';
-          this.hiddenTextarea.style.width = rect.width + 'px';
-          this.hiddenTextarea.style.height = rect.height + 'px';
+
+          // Compute the scale transform between fabric coords and DOM coords
+          var canvasRect = this.canvas.lowerCanvasEl.getBoundingClientRect();
+          var xScale = canvasRect.width / this.canvas.width;
+          var yScale = canvasRect.height / this.canvas.height;
+
+          this.hiddenTextarea.style.top = rect.top * xScale + 'px';
+          this.hiddenTextarea.style.left = rect.left * yScale + 'px';
+          this.hiddenTextarea.style.width = rect.width * xScale + 'px';
+          this.hiddenTextarea.style.height = rect.height * yScale + 'px';
         }
       }.bind(this);
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -21,9 +21,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
           var rect = this.getBoundingRect();
 
           // Compute the scale transform between fabric coords and DOM coords
-          var canvasRect = this.canvas.lowerCanvasEl.getBoundingClientRect();
-          var xScale = canvasRect.width / this.canvas.width;
-          var yScale = canvasRect.height / this.canvas.height;
+          var canvasRect = this.canvas.lowerCanvasEl.getBoundingClientRect(),
+            xScale = canvasRect.width / this.canvas.width,
+            yScale = canvasRect.height / this.canvas.height;
 
           this.hiddenTextarea.style.top = rect.top * xScale + 'px';
           this.hiddenTextarea.style.left = rect.left * yScale + 'px';

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -7,8 +7,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: absolute; opacity: 0; font-size: 1pt;' +
-                                        ' left: -9999px; width: 8888px; height: 10px; z-index: -999;';
+    this.hiddenTextarea.style.cssText = 'position: absolute; opacity: 0; font-size: 0pt;' +
+                                        'color: transparent; z-index: -999;';
     //If at all possible, show the textarea within the canvas wrapper where it can exist
     //at the same height as the iText display. This prevents iOS from scrolling to whatever
     //height the textarea is at when you type.
@@ -20,6 +20,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
           //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
           var rect = this.getBoundingRect();
           this.hiddenTextarea.style.top = rect.top + 'px';
+          this.hiddenTextarea.style.left = rect.left + 'px';
+          this.hiddenTextarea.style.width = rect.width + 'px';
+          this.hiddenTextarea.style.height = rect.height + 'px';
         }
       }.bind(this);
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -13,25 +13,26 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     //at the same height as the iText display. This prevents iOS from scrolling to whatever
     //height the textarea is at when you type.
     if (this.canvas && this.canvas.wrapperEl) {
-        this.canvas.wrapperEl.appendChild(this.hiddenTextarea);
+      this.canvas.wrapperEl.appendChild(this.hiddenTextarea);
 
-        var updateHiddenTextareaPosition = function (){
-          if (this.isEditing && this.canvas.getActiveObject() === this) {
-            //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
-            var rect = this.getBoundingRect();
-            this.hiddenTextarea.style.top = rect.top + 'px';
-          }
-        }.bind(this);
+      var updateHiddenTextareaPosition = function () {
+        if (this.isEditing && this.canvas.getActiveObject() === this) {
+          //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
+          var rect = this.getBoundingRect();
+          this.hiddenTextarea.style.top = rect.top + 'px';
+        }
+      }.bind(this);
 
-        this.on('event:scaling', updateHiddenTextareaPosition);
-        this.on('event:moving', updateHiddenTextareaPosition);
-        this.on('editing:exited', function(){
-          this.off('event:scaling', updateHiddenTextareaPosition);
-          this.off('event:moving', updateHiddenTextareaPosition);
-        }.bind(this));
-        updateHiddenTextareaPosition();
-    } else {
-        fabric.document.body.appendChild(this.hiddenTextarea);
+      this.on('event:scaling', updateHiddenTextareaPosition);
+      this.on('event:moving', updateHiddenTextareaPosition);
+      this.on('editing:exited', function() {
+        this.off('event:scaling', updateHiddenTextareaPosition);
+        this.off('event:moving', updateHiddenTextareaPosition);
+      }.bind(this));
+      updateHiddenTextareaPosition();
+    }
+    else {
+      fabric.document.body.appendChild(this.hiddenTextarea);
     }
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -7,9 +7,32 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: fixed; bottom: 20px; left: 0px; opacity: 0;'
-                                        + ' width: 0px; height: 0px; z-index: -999;';
-    fabric.document.body.appendChild(this.hiddenTextarea);
+    this.hiddenTextarea.style.cssText = 'position: absolute; opacity: 0; font-size: 1pt;' +
+                                        ' left: -9999px; width: 8888px; height: 10px; z-index: -999;';
+    //If at all possible, show the textarea within the canvas wrapper where it can exist
+    //at the same height as the iText display. This prevents iOS from scrolling to whatever
+    //height the textarea is at when you type.
+    if (this.canvas && this.canvas.wrapperEl) {
+        this.canvas.wrapperEl.appendChild(this.hiddenTextarea);
+
+        var updateHiddenTextareaPosition = function (){
+          if (this.isEditing && this.canvas.getActiveObject() === this) {
+            //The text's bounding rectangle, IN CANVAS SPACE (not fabric logical coordinates)
+            var rect = this.getBoundingRect();
+            this.hiddenTextarea.style.top = rect.top + 'px';
+          }
+        }.bind(this);
+
+        this.on('event:scaling', updateHiddenTextareaPosition);
+        this.on('event:moving', updateHiddenTextareaPosition);
+        this.on('editing:exited', function(){
+          this.off('event:scaling', updateHiddenTextareaPosition);
+          this.off('event:moving', updateHiddenTextareaPosition);
+        }.bind(this));
+        updateHiddenTextareaPosition();
+    } else {
+        fabric.document.body.appendChild(this.hiddenTextarea);
+    }
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'keypress', this.onKeyPress.bind(this));


### PR DESCRIPTION
Previously, it was positioned as position: fixed at the bottom of
the window. However, on iOS, this has the effect of scrolling the
page all the way to the bottom when the user types. This is because
position: fixed in iOS allows the page to scroll behind the fixed
element if there is a focused input in it.

Now, we put the textarea off to the left at the same height as the
top of the iText; there should be no scrolling. We also make some
attempt to update the position when the text moves on the screen.

Fixes #1985 