### PR TITLE
Make toJSON/toSVG behave sensibly with an active selection group

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -289,7 +289,7 @@
     */
     realizeTransform: function(object) {
       this._moveFlippedObject(object);
-      this._restoreObjectState(object);
+      this._setObjectPosition(object);
       return object;
     },
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -280,6 +280,19 @@
     },
 
     /**
+     * Realises the transform from this group onto the supplied object
+     * i.e. it tells you what would happen if the supplied object was in
+     * the group, and then the group was destroyed. It mutates the supplied
+     * object.
+     * @param {fabric.Object} object
+     * @return {fabric.Object} transformedObject
+    */
+    realizeTransform: function(object) {
+      this._moveFlippedObject(object);
+      this._restoreObjectState(object);
+      return object;
+    },
+    /**
      * Moves a flipped object to the position where it's displayed
      * @private
      * @param {fabric.Object} object

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1104,9 +1104,8 @@
       //be transformed appropriately
       //i.e. it should be serialised as it would appear if the selection group
       //were to be destroyed.
-      var originalProperties = this._realizeGroupTransformOnObject(instance);
-
-      var object = instance[methodName](propertiesToInclude);
+      var originalProperties = this._realizeGroupTransformOnObject(instance),
+          object = instance[methodName](propertiesToInclude);
       if (!this.includeDefaultValues) {
         instance.includeDefaultValues = originalValue;
       }
@@ -1133,7 +1132,8 @@
         });
         this.getActiveGroup().realizeTransform(instance);
         return originalValues;
-      } else {
+      }
+      else {
         return null;
       }
     },

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1278,18 +1278,17 @@
      * @private
      */
     _setSVGObjects: function(markup, reviver) {
-      var activeGroup = this.getActiveGroup();
-      if (activeGroup) {
-        this.discardActiveGroup();
-      }
+      var selectionGroup = this.getActiveGroup();
       for (var i = 0, objects = this.getObjects(), len = objects.length; i < len; i++) {
-        markup.push(objects[i].toSVG(reviver));
-      }
-      if (activeGroup) {
-        this.setActiveGroup(new fabric.Group(activeGroup.getObjects()));
-        activeGroup.forEachObject(function(o) {
-          o.set('active', true);
-        });
+        if (selectionGroup && objects[i].group === selectionGroup) {
+          //If the object is in a selection group, simulate what would happen to that
+          //object when the group is deselected
+          var objectClone = objects[i].clone();
+          selectionGroup.realizeTransform(objectClone);
+          markup.push(objectClone.toSVG(reviver));
+        } else {
+          markup.push(objects[i].toSVG(reviver));
+        }
       }
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1069,11 +1069,6 @@
      */
     _toObjectMethod: function (methodName, propertiesToInclude) {
 
-      var activeGroup = this.getActiveGroup();
-      if (activeGroup) {
-        this.discardActiveGroup();
-      }
-
       var data = {
         objects: this._toObjects(methodName, propertiesToInclude)
       };
@@ -1081,20 +1076,6 @@
       extend(data, this.__serializeBgOverlay());
 
       fabric.util.populateWithProperties(this, data, propertiesToInclude);
-
-      if (activeGroup) {
-        this.setActiveGroup(new fabric.Group(activeGroup.getObjects(), {
-          originX: 'center',
-          originY: 'center'
-        }));
-        activeGroup.forEachObject(function(o) {
-          o.set('active', true);
-        });
-
-        if (this._currentTransform) {
-          this._currentTransform.target = this.getActiveGroup();
-        }
-      }
 
       return data;
     },
@@ -1118,6 +1099,16 @@
         originalValue = instance.includeDefaultValues;
         instance.includeDefaultValues = false;
       }
+
+      //If the object is part of the current selection group, it should
+      //be transformed appropriately
+      //i.e. it should be serialised as it would appear if the selection group
+      //were to be destroyed.
+      if (instance.group && instance.group === this.getActiveGroup()) {
+        instance = instance.clone();
+        this.getActiveGroup().realizeTransform(instance);
+      }
+
       var object = instance[methodName](propertiesToInclude);
       if (!this.includeDefaultValues) {
         instance.includeDefaultValues = originalValue;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1146,9 +1146,7 @@
      */
     _unwindGroupTransformOnObject: function(instance, originalValues) {
       if (originalValues) {
-        Object.keys(originalValues).forEach(function(prop) {
-          instance[prop] = originalValues[prop];
-        });
+        instance.set(originalValues);
       }
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1112,7 +1112,7 @@
       }
 
       //Undo the damage we did by changing all of its properties
-      this._unwindGroupTransformOnObject(instance, originalProperties)
+      this._unwindGroupTransformOnObject(instance, originalProperties);
 
       return object;
     },
@@ -1305,7 +1305,6 @@
      * @private
      */
     _setSVGObjects: function(markup, reviver) {
-      var selectionGroup = this.getActiveGroup();
       for (var i = 0, objects = this.getObjects(), len = objects.length; i < len; i++) {
         var instance = objects[i],
             //If the object is in a selection group, simulate what would happen to that

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1277,7 +1277,8 @@
           var objectClone = objects[i].clone();
           selectionGroup.realizeTransform(objectClone);
           markup.push(objectClone.toSVG(reviver));
-        } else {
+        }
+        else {
           markup.push(objects[i].toSVG(reviver));
         }
       }


### PR DESCRIPTION
Calling toJSON or toSVG on a canvas whilst there is an active selection group causes it to be destroyed & recreated. This causes a number of nasties to happen, as described in https://github.com/kangax/fabric.js/issues/1876. This PR changes the way these methods work to avoid needing to do this; instead of realising the result of the group's transform on its objects by destroying the group, the group gains a method for doing this explicitly, and toJSON/toSVG pass clones of selected objects into this method.

This is a version of @slashgrin's fiddle including this patch, demonstrating that the problem has gone:
http://jsfiddle.net/2yy2t5nw/6/

These fiddles verify that toJSON/toSVG seem to be doing the right thing:
http://jsfiddle.net/2yy2t5nw/7/
http://jsfiddle.net/zsc1p82w/8/