### PR TITLE
Fix cache change bug for arcs command

### DIFF
--- a/src/util/arc.js
+++ b/src/util/arc.js
@@ -153,16 +153,17 @@
   fabric.util.getBoundsOfArc = function(fx, fy, rx, ry, rot, large, sweep, tx, ty) {
 
     var fromX = 0, fromY = 0, bound = [ ], bounds = [ ],
-    segs = arcToSegments(tx - fx, ty - fy, rx, ry, large, sweep, rot);
+    segs = arcToSegments(tx - fx, ty - fy, rx, ry, large, sweep, rot),
+    boundCopy = [[ ], [ ]];
 
     for (var i = 0, len = segs.length; i < len; i++) {
       bound = getBoundsOfCurve(fromX, fromY, segs[i][0], segs[i][1], segs[i][2], segs[i][3], segs[i][4], segs[i][5]);
-      bound[0].x += fx;
-      bound[0].y += fy;
-      bound[1].x += fx;
-      bound[1].y += fy;
-      bounds.push(bound[0]);
-      bounds.push(bound[1]);
+      boundCopy[0].x = bound[0].x + fx;
+      boundCopy[0].y = bound[0].y + fy;
+      boundCopy[1].x = bound[1].x + fx;
+      boundCopy[1].y = bound[1].y + fy;
+      bounds.push(boundCopy[0]);
+      bounds.push(boundCopy[1]);
       fromX = segs[i][4];
       fromY = segs[i][5];
     }


### PR DESCRIPTION
Create a copy of the cache instead of modify it.

closes #1965

they do not increase in sizes anymore :
![image](https://cloud.githubusercontent.com/assets/1194048/6432073/345c40de-c045-11e4-8873-817a44483723.png)
