### PR TITLE
Fixes #2034 Mouse hit detection on active groups

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -808,9 +808,10 @@
       var target,
           pointer = this.getPointer(e, true),
           i = this._objects.length;
-
+     
+     // Do not check for currently grouped objects, since we check the parent group itself.
       while (i--) {
-        if (this._checkTarget(e, this._objects[i], pointer)){
+        if (!this._objects[i].group && this._checkTarget(e, this._objects[i], pointer)){
           this.relatedTarget = this._objects[i];
           target = this._objects[i];
           break;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -808,7 +808,6 @@
       var target,
           pointer = this.getPointer(e, true),
           i = this._objects.length;
-     
      // Do not check for currently grouped objects, since we check the parent group itself.
       while (i--) {
         if (!this._objects[i].group && this._checkTarget(e, this._objects[i], pointer)){


### PR DESCRIPTION
Skips the checking of grouped objects within _searchPossibleTargets since we already check the group as a whole target itself in ```_findTarget```.  

Previously, grouped objects could be picked up as individual mouse targets outside of their active groups boundaries since their ```oCoords``` change temporarily while grouped.  This caused the appearance of invisible mouse targets while having an active group selection.



This fixes issue #2034 