### PR TITLE
Antialiased clipping in Chrome

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -342,9 +342,7 @@
     _onMouseDownInDrawingMode: function(e) {
       this._isCurrentlyDrawing = true;
       this.discardActiveObject(e).renderAll();
-      if (this.clipTo) {
-        fabric.util.clipContext(this, this.contextTop);
-      }
+
       var ivt = fabric.util.invertTransform(this.viewportTransform),
           pointer = fabric.util.transformPoint(this.getPointer(e, true), ivt);
       this.freeDrawingBrush.onMouseDown(pointer);
@@ -366,6 +364,7 @@
             pointer = fabric.util.transformPoint(this.getPointer(e, true), ivt);
         this.freeDrawingBrush.onMouseMove(pointer);
       }
+      fabric.util.clipContext(this.clipTo || this.clipAllTo, this.contextTop);
       this.setCursor(this.freeDrawingCursor);
       this.fire('mouse:move', { e: e });
 
@@ -381,9 +380,6 @@
      */
     _onMouseUpInDrawingMode: function(e) {
       this._isCurrentlyDrawing = false;
-      if (this.clipTo) {
-        this.contextTop.restore();
-      }
       this.freeDrawingBrush.onMouseUp();
       this.fire('mouse:up', { e: e });
 

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -226,14 +226,13 @@
       }
 
       ctx.save();
-      this.clipTo && fabric.util.clipContext(this, ctx);
 
       // the array is now sorted in order of highest first, so start from end
       for (var i = 0, len = this._objects.length; i < len; i++) {
         this._renderObject(this._objects[i], ctx);
       }
 
-      this.clipTo && ctx.restore();
+      fabric.util.clipContext(this.clipTo, ctx);
 
       ctx.restore();
     },

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -988,9 +988,8 @@
       }
       this._setOpacity(ctx);
       this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
       this._render(ctx, noTransform);
-      this.clipTo && ctx.restore();
+      fabric.util.clipContext(this.clipTo, ctx);
       this._removeShadow(ctx);
       this._restoreCompositeOperation(ctx);
 

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -475,9 +475,8 @@
       }
       this._setOpacity(ctx);
       this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
       this._render(ctx, noTransform);
-      this.clipTo && ctx.restore();
+      fabric.util.clipContext(this.clipTo, ctx);
       this._removeShadow(ctx);
       this._restoreCompositeOperation(ctx);
 

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -86,11 +86,10 @@
       this.transform(ctx);
 
       this._setShadow(ctx);
-      this.clipTo && fabric.util.clipContext(this, ctx);
       for (var i = 0, l = this.paths.length; i < l; ++i) {
         this.paths[i].render(ctx, true);
       }
-      this.clipTo && ctx.restore();
+      fabric.util.clipContext(this.clipTo, ctx);
       this._removeShadow(ctx);
       ctx.restore();
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -346,9 +346,6 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
-
-      this.clipTo && fabric.util.clipContext(this, ctx);
-
       this._renderTextBackground(ctx);
       this._translateForTextAlign(ctx);
       this._renderText(ctx);
@@ -358,7 +355,7 @@
       }
 
       this._renderTextDecoration(ctx);
-      this.clipTo && ctx.restore();
+      fabric.util.clipContext(this.clipTo, ctx);
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -113,6 +113,21 @@
     clipTo: null,
 
     /**
+     * Function that determines clipping of all the canvas, including the background
+     * If clipBackground is false, this will no take effect
+     * @type Function
+     * @default
+     */
+    clipAllTo: null,
+
+     /**
+     * Indicates whether the backGroundImage get clipped or not by clip the clipToBackground context if defined, or by clipTo context if defined
+     * @type Boolean
+     * @default
+     */
+    clipBackground: true,
+
+    /**
      * Indicates whether object controls (borders/controls) are rendered above overlay image
      * @type Boolean
      * @default
@@ -834,16 +849,20 @@
 
       this.fire('before:render');
 
-      if (this.clipTo) {
-        fabric.util.clipContext(this, canvasToDrawOn);
-      }
-
-      this._renderBackground(canvasToDrawOn);
       this._renderObjects(canvasToDrawOn, activeGroup);
       this._renderActiveGroup(canvasToDrawOn, activeGroup);
 
-      if (this.clipTo) {
-        canvasToDrawOn.restore();
+      if (this.clipTo && (!this.clipBackground || this.clipAllTo)) {
+        fabric.util.clipContext(this.clipTo, canvasToDrawOn);
+      }
+
+      canvasToDrawOn.save();
+      canvasToDrawOn.globalCompositeOperation = 'destination-over';
+      this._renderBackground(canvasToDrawOn);
+      canvasToDrawOn.restore();
+
+      if (this.clipBackground && (this.clipAllTo || this.clipTo)) {
+        fabric.util.clipContext(this.clipAllTo || this.clipTo, canvasToDrawOn);
       }
 
       this._renderOverlay(canvasToDrawOn);

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -445,14 +445,17 @@
     /**
      * @static
      * @memberOf fabric.util
-     * @param {fabric.Object} receiver Object implementing `clipTo` method
+     * @param {Function} clipTo Function implementing the clipping
      * @param {CanvasRenderingContext2D} ctx Context to clip
      */
-    clipContext: function(receiver, ctx) {
-      ctx.save();
-      ctx.beginPath();
-      receiver.clipTo(ctx);
-      ctx.clip();
+    clipContext: function(clipTo, ctx) {
+      if (clipTo && typeof clipTo === 'function') {
+        ctx.save();
+        ctx.beginPath();
+        ctx.globalCompositeOperation = 'destination-in';
+        clipTo(ctx);
+        ctx.restore();
+      }
     },
 
     /**


### PR DESCRIPTION
Perform canvas and object clipping using blending. This will be rendered with antialias in all browsers, including Chrome.
Here is the same example with [antialiased clipping](http://jsfiddle.net/2yeLoves/1/) vs [current Fabric.js](http://jsfiddle.net/5c5r8df0/). Use Chrome to see the difference.

It also allows to define 2 clipping masks for canvas:

  * `canvas.clipAllTo` will always clip everything, including the background
  * `canvas.clipTo` will clip the objects but not the background if `clipBackground == false` or `clipAllTo` is defined

This is useful for example on T-Shirt custom designing: you define the background color and a mask with the shape of the shirt, and another mask to clip the contents of the printing area.

I will add examples for every case.

Fixes #1915 