### PR TITLE
Clear cache on setStyle on itext

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -284,6 +284,8 @@
           this._extendStyles(i, styles);
         }
       }
+      /* not included in _extendStyles to avoid clearing cache more than once */
+      this._clearCache();
       return this;
     },
 
@@ -299,7 +301,6 @@
       if (!this.styles[loc.lineIndex][loc.charIndex]) {
         this.styles[loc.lineIndex][loc.charIndex] = { };
       }
-
       fabric.util.object.extend(this.styles[loc.lineIndex][loc.charIndex], styles);
     },
 


### PR DESCRIPTION
a proper style check before rendering could trigger cache clearing when users directly change the properties of the object, but may be not cost effective or easy to implement.
