### PR TITLE
Track IText instances per-canvas, not globally.

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -184,9 +184,6 @@
       this.styles = options ? (options.styles || { }) : { };
       this.callSuper('initialize', text, options);
       this.initBehavior();
-
-      fabric.IText.instances.push(this);
-
     },
 
     /**
@@ -1110,13 +1107,4 @@
   fabric.IText.fromObject = function(object) {
     return new fabric.IText(object.text, clone(object));
   };
-
-  /**
-   * Contains all fabric.IText objects that have been created
-   * @static
-   * @memberof fabric.IText
-   * @type Array
-   */
-  fabric.IText.instances = [ ];
-
 })();

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -1,6 +1,11 @@
 (function() {
+  var canvas = this.canvas = new fabric.Canvas();
 
-  QUnit.module('fabric.IText');
+  QUnit.module('fabric.IText', {
+    teardown: function() {
+      canvas.clear();
+    }
+  });
 
   var ITEXT_OBJECT = {
     'type':                     'text',
@@ -59,7 +64,25 @@
 
   test('instances', function() {
     var iText = new fabric.IText('test');
-    var lastInstance = fabric.IText.instances[fabric.IText.instances.length - 1];
+
+    // Not on a sketchpad; storing it in instances array already would leak it forever.
+    var instances = canvas._iTextInstances && canvas._iTextInstances;
+    var lastInstance = instances && instances[instances.length - 1];
+    equal(lastInstance, undefined);
+
+    canvas.add(iText);
+    instances = canvas._iTextInstances && canvas._iTextInstances;
+    lastInstance = instances && instances[instances.length - 1];
+    equal(lastInstance, iText);
+
+    canvas.remove(iText);
+    instances = canvas._iTextInstances && canvas._iTextInstances;
+    lastInstance = instances && instances[instances.length - 1];
+    equal(lastInstance, undefined);
+
+    // Should survive being added again after removal.
+    canvas.add(iText);
+    lastInstance = canvas._iTextInstances && canvas._iTextInstances[canvas._iTextInstances.length - 1];
     equal(lastInstance, iText);
   });
 


### PR DESCRIPTION
Previously instances of the IText shape were added to a globally-shared
array when they were created. There are two problems with this approach:

1) Interactions with one canvas affect others. I would never expect
   text in one canvas to exit edit mode just because I interacted with
   some otherwise-unrelated canvas.

2) Every IText instance leaks. There is no mechanism to clean up references
   to IText instances in the global array, so every such instance will
   hang around in memory forever, regardless of whether it is removed from
   the canvas or if the canvas itself is removed.

Discovered while profiling memory usage in Chrome.