### PR TITLE
Updated fabric.js, added mouseout on upperCanvas element

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -9142,6 +9142,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
       addListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
       addListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       addListener(this.upperCanvasEl, 'mousewheel', this._onMouseWheel);
+      addListener(this.upperCanvasEl, 'mouseout', this._onMouseOut);
 
       // touch events
       addListener(this.upperCanvasEl, 'touchstart', this._onMouseDown);
@@ -9170,6 +9171,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
       this._onLongPress = this._onLongPress.bind(this);
       this._onOrientationChange = this._onOrientationChange.bind(this);
       this._onMouseWheel = this._onMouseWheel.bind(this);
+      this._onMouseOut = this._onMouseOut.bind(this);
     },
 
     /**
@@ -9181,6 +9183,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
       removeListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
       removeListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       removeListener(this.upperCanvasEl, 'mousewheel', this._onMouseWheel);
+      removeListener(this.upperCanvasEl, 'mouseout', this._onMouseOut);
 
       removeListener(this.upperCanvasEl, 'touchstart', this._onMouseDown);
       removeListener(this.upperCanvasEl, 'touchmove', this._onMouseMove);
@@ -9303,6 +9306,14 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
     _onMouseMove: function (e) {
       !this.allowTouchScrolling && e.preventDefault && e.preventDefault();
       this.__onMouseMove(e);
+    },
+    
+    /**
+     * @private
+     * @param {Event} e Event object fired on mouseout
+     */
+	_onMouseOut: function (e) {
+      this.__onMouseOut(e);
     },
 
     /**
@@ -9672,6 +9683,18 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
 
       this.fire('mouse:move', { target: target, e: e });
       target && target.fire('mousemove', { e: e });
+    },
+    
+    /**
+      * Method that defines the actions when mouse is out of the main canvas.
+      * @private
+      * @param {Event} e Event object fired on mouseout
+      */
+	__onMouseOut: function (e) {
+		var target;
+		target = this.findTarget(e);
+		this._hoveredTarget = target;
+		this._fireOverOutEvents();
     },
 
     /**


### PR DESCRIPTION
There are **mouseover** & **mouseout** events for objects, which works fine. But there is a case where **mouseout** on an object does not trigger. Lets assume we have an overlay div on the main canvas and that div is placed right below the object. Now when you hover over the object **mouseover** gets triggered. But when you move your mouse to the overlay div the **mouseover** does not trigger. That is because these events are bind to **upper-canvas** and when mouse is on the overlay div the **mouseover** and **mouseout** does not gets trigger. 

Or lets forget about overlay div. Lets assume the object is on the left. And when you mouse out of the object to left in this [fiddle](https://jsfiddle.net/45vfbgw1/2/) you will notice the **mouseout** does not trigger. Because now mouse is out of the main canvas.

So i have added a **mouseout** event for **upper-canvas**. When this event gets trigger it will call the **mouseout** of the last **mouseover** object.

I have created 2 fiddles to explain the issue.

[Fiddle using the current fabirc.js:](https://jsfiddle.net/45vfbgw1/) In this fiddle you can see when you **mouseover** the big red box the **mouseover** event triggers. But when you move the mouse right below the object to the overlay div, the **mouseout** does not trigger.

[Fiddle with solution:](http://jsfiddle.net/wm69g3ed/)