### PR TITLE
Fix doc for setAngle

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -36,6 +36,7 @@ fabric.isTouchSupported = "ontouchstart" in fabric.document.documentElement;
 fabric.isLikelyNode = typeof Buffer !== 'undefined' &&
                       typeof window === 'undefined';
 
+/* _FROM_SVG_START_ */
 /**
  * Attributes parsed from all SVG elements
  * @type array
@@ -49,6 +50,7 @@ fabric.SHARED_ATTRIBUTES = [
   "stroke-linejoin", "stroke-miterlimit",
   "stroke-opacity", "stroke-width"
 ];
+/* _FROM_SVG_END_ */
 
 /**
  * Pixel per Inch as a default value set to 96. Can be changed for more realistic conversion.

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -451,12 +451,10 @@
      * @private
      */
     _beforeTransform: function(e, target) {
-      var corner;
-
       this.stateful && target.saveState();
 
       // determine if it's a drag or rotate case
-      if ((corner = target._findTargetCorner(this.getPointer(e)))) {
+      if (target._findTargetCorner(this.getPointer(e))) {
         this.onBeforeScaleRotate(target);
       }
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -192,15 +192,6 @@
      */
 
     /**
-     * Sets object's {@link fabric.Object#angle|angle}
-     * @method setAngle
-     * @memberOf fabric.Object.prototype
-     * @param {Number} value Angle value (in degrees)
-     * @return {fabric.Object} thisArg
-     * @chainable
-     */
-
-    /**
      * Retrieves object's {@link fabric.Object#top|top position}
      * @method getTop
      * @memberOf fabric.Object.prototype
@@ -1402,7 +1393,7 @@
 
     /**
      * Sets "angle" of an instance
-     * @param {Number} angle Angle value
+     * @param {Number} angle Angle value (in degrees)
      * @return {fabric.Object} thisArg
      * @chainable
      */


### PR DESCRIPTION
Sorry, this PR is not affect to the feature...

1. src/shapes/object.class.js
In docs for fabric.Object and its extended class,
there are two definition for setAngle.
http://fabricjs.com/docs/fabric.Object.html#setAngle

2. HEADER.js
fabric.SHARED_ATTRIBUTES is used for parsing svg.
Therefore, it would be unnecessary for no parser module build.

3. src/mixins/canvas_events.mixin.js
Remove unused variable.