### PR TITLE
Render cursor on upper canvas

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -198,7 +198,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
       if (this.flipX) {
         // when oject is horizontally flipped we reverse chars
-        this._textLines[i] = line.split('').reverse().join('');
+        this._textLines[i] = line.reverse().join('');
       }
 
       for (var j = 0, jlen = line.length; j < jlen; j++) {

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -476,16 +476,17 @@
      * @param {Object} boundaries
      */
     renderCursor: function(boundaries) {
-      var ctx = this.ctx;
+      var ctx = this.canvas.contextTop || this.ctx;
 
       ctx.save();
+      this.transform(ctx);
 
       var cursorLocation = this.get2DCursorLocation(),
           lineIndex = cursorLocation.lineIndex,
           charIndex = cursorLocation.charIndex,
           charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
           leftOffset = (lineIndex === 0 && charIndex === 0)
-                    ? this._getCachedLineOffset(lineIndex, this.text.split(this._reNewline))
+                    ? this._getCachedLineOffset(lineIndex)
                     : boundaries.leftOffset;
 
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
@@ -506,9 +507,10 @@
      * @param {Object} boundaries Object with left/top/leftOffset/topOffset
      */
     renderSelection: function(chars, boundaries) {
-      var ctx = this.ctx;
+      var ctx = this.canvas.contextTop || this.ctx;
 
       ctx.save();
+      this.transform(ctx);
 
       ctx.fillStyle = this.selectionColor;
 


### PR DESCRIPTION
This PR mainly avoid calling canvas.renderAll during iText cursor animation.

Both the tick and the render cursor or selection check if there is available contextTop and use that or standard ctx.

It looks very simple, i hope i did not introduce any bug
Can you think of some interference with other upper canvas drawing?
( overlay image? )

closes #2016