### PR TITLE
Fix hit detection on the active group after zooming.

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -620,10 +620,14 @@
      * @chainable true
      */
     setViewportTransform: function (vpt) {
+      var activeGroup = this.getActiveGroup();
       this.viewportTransform = vpt;
       this.renderAll();
       for (var i = 0, len = this._objects.length; i < len; i++) {
         this._objects[i].setCoords();
+      }
+      if (activeGroup) {
+        activeGroup.setCoords();
       }
       return this;
     },


### PR DESCRIPTION
The active group's coordinates don't get updated when the canvas's viewport transform changes. Therefore sometimes you can drag the group from outside of its visible bounds, and other times the mouse event will "miss" the group:

![zoom-hit-testing](https://cloud.githubusercontent.com/assets/887005/6924342/8ae64e3a-d79d-11e4-8d2e-1b546a22ff46.gif)

This PR fixes `setViewportTransform` to update the active group's coordinates (along with all the objects which are already updated there).