### PR TITLE
Fix transform matrix of particular complex situation

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -448,12 +448,12 @@
     if (!(scaleX !== 1 || scaleY !== 1 || minX !== 0 || minY !== 0)) {
       return;
     }
-    matrix = 'matrix(' + scaleX +
+    matrix = ' matrix(' + scaleX +
                   ' 0' +
                   ' 0 ' +
                   scaleY + ' ' +
                   (minX * scaleX) + ' ' +
-                  (minY * scaleY) + ')';
+                  (minY * scaleY) + ') ';
 
     if (element.tagName === 'svg') {
       el = element.ownerDocument.createElement('g');
@@ -464,7 +464,7 @@
     }
     else {
       el = element;
-      matrix += el.getAttribute('transform');
+      matrix = el.getAttribute('transform') + matrix;
     }
 
     el.setAttribute('transform', matrix);


### PR DESCRIPTION
The birthday cake ( very strange svg ) is broken again:
![image](https://cloud.githubusercontent.com/assets/1194048/6930288/1d8da18e-d802-11e4-8a09-5179d16473fa.png)

The problem arose when we implemented nested viewbox, in conjuction with the use of symbol tag with a viewbox and a transform attribute on the "use" tag.

Now is fixed:
![image](https://cloud.githubusercontent.com/assets/1194048/6930308/4af1d73a-d802-11e4-8869-b879172e1060.png)

Interesting firefox still cannot render this svg:
![image](https://cloud.githubusercontent.com/assets/1194048/6930312/5e96208e-d802-11e4-9c83-c1a96b2f3770.png)

while chrome does
![image](https://cloud.githubusercontent.com/assets/1194048/6930315/6a0f4346-d802-11e4-9976-57687bad33d0.png)

And internet explorer is missing the gradient information
![image](https://cloud.githubusercontent.com/assets/1194048/6930376/fca0579a-d802-11e4-810b-753feb923960.png)

