### PR TITLE
Render cursor - fix for viewportTransfrom

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -480,11 +480,8 @@
       if (this.canvas.contextTop) {
         ctx = this.canvas.contextTop;
         ctx.save();
+        ctx.transform.apply(ctx, this.canvas.viewportTransform);
         this.transform(ctx);
-        this.upperCanvas.scale(
-          this.canvas.viewportTransform[0],
-          this.canvas.viewportTransform[3]
-        );
       } else {
         ctx = this.ctx;
         ctx.save();

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -476,10 +476,19 @@
      * @param {Object} boundaries
      */
     renderCursor: function(boundaries) {
-      var ctx = this.canvas.contextTop || this.ctx;
-
-      ctx.save();
-      this.transform(ctx);
+      var ctx; 
+      if (this.canvas.contextTop) {
+        ctx = this.canvas.contextTop;
+        ctx.save();
+        this.transform(ctx);
+        this.upperCanvas.scale(
+          this.canvas.viewportTransform[0],
+          this.canvas.viewportTransform[3]
+        );
+      } else {
+        ctx = this.ctx;
+        ctx.save();
+      }
 
       var cursorLocation = this.get2DCursorLocation(),
           lineIndex = cursorLocation.lineIndex,

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -476,13 +476,14 @@
      * @param {Object} boundaries
      */
     renderCursor: function(boundaries) {
-      var ctx; 
+      var ctx;
       if (this.canvas.contextTop) {
         ctx = this.canvas.contextTop;
         ctx.save();
         ctx.transform.apply(ctx, this.canvas.viewportTransform);
         this.transform(ctx);
-      } else {
+      }
+      else {
         ctx = this.ctx;
         ctx.save();
       }


### PR DESCRIPTION
If using upperContext, we have to transform manually.
(still do not understand why we should check for upperContext, is possible to edit text on staticCanvas? )

closes #2077 