### PR TITLE
Clean text from svg

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1023,7 +1023,7 @@
     if (!options.originX) {
       options.originX = 'left';
     }
-    var textContent = element.textContent.replace(/\n+/g, '').replace(/\s+/g, ' '),
+    var textContent = element.textContent.replace(/^\s+|\s+$|\n+/g, '').replace(/\s+/g, ' '),
         text = new fabric.Text(textContent, options),
         /*
           Adjust positioning:

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1023,7 +1023,8 @@
     if (!options.originX) {
       options.originX = 'left';
     }
-    var text = new fabric.Text(element.textContent, options),
+    var textContent = element.textContent.replace(/\n+/g, '').replace(/\s+/g, ' '),
+        text = new fabric.Text(textContent, options),
         /*
           Adjust positioning:
             x/y attributes in SVG correspond to the bottom-left corner of text bounding box


### PR DESCRIPTION
closes #2088.

Text cleaning from svg.
Do not import newlines, trailing spaces and so on.