### PR TITLE
Changes in renderAll

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -293,8 +293,8 @@
 
       target.hasBorders = target.transparentCorners = false;
 
-      this._draw(this.contextCache, target);
-
+      target.render(this.contextCache);
+      target._renderControls(this.contextCache);
       target.hasBorders = hasBorders;
       target.transparentCorners = transparentCorners;
 
@@ -1111,18 +1111,11 @@
     drawControls: function(ctx) {
       var activeGroup = this.getActiveGroup();
       if (activeGroup) {
-        this._drawGroupControls(ctx, activeGroup);
+        activeGroup._renderControls(ctx);
       }
       else {
         this._drawObjectsControls(ctx);
       }
-    },
-
-    /**
-     * @private
-     */
-    _drawGroupControls: function(ctx, activeGroup) {
-      activeGroup._renderControls(ctx);
     },
 
     /**


### PR DESCRIPTION
to be discussed and evaluated.
It just looks more clean, but maybe is just me.

What it does:

check if there is an activegroup and a not preserveObjectStacking.
in this case divide the objects in 2 groups, the normal and the one in activegroup.
Then renders the normal objects and later the activegroup it self.

Eliminates should render object, eliminates fastpath, eliminates the renderActiveGroup.
For sure it save some logic and processing, do not know if makes mess.

@kangax  @Kienz  if you want to have a look...