### PR TITLE
Fix group initialization

### DIFF
--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -16,6 +16,13 @@
     return new fabric.Group([ rect1, rect2 ], {strokeWidth: 0});
   }
 
+  function makeGroupWith2ObjectsWithOpacity() {
+    var rect1 = new fabric.Rect({ top: 100, left: 100, width: 30, height: 10, strokeWidth: 0, opacity: 0.5 }),
+        rect2 = new fabric.Rect({ top: 120, left: 50, width: 10, height: 40, strokeWidth: 0, opacity: 0.8 });
+
+    return new fabric.Group([ rect1, rect2 ], {strokeWidth: 0});
+  }
+
   function makeGroupWith4Objects() {
     var rect1 = new fabric.Rect({ top: 100, left: 100, width: 30, height: 10 }),
         rect2 = new fabric.Rect({ top: 120, left: 50, width: 10, height: 40 }),
@@ -363,7 +370,7 @@ test('toObject without default values', function() {
   });
 
   asyncTest('fromObject', function() {
-    var group = makeGroupWith2Objects();
+    var group = makeGroupWith2ObjectsWithOpacity();
 
     ok(typeof fabric.Group.fromObject == 'function');
     var groupObject = group.toObject();
@@ -374,6 +381,9 @@ test('toObject without default values', function() {
       var objectFromNewGroup = newGroupFromObject.toObject();
 
       ok(newGroupFromObject instanceof fabric.Group);
+
+      deepEqual(objectFromOldGroup.objects[0], objectFromNewGroup.objects[0]);
+      deepEqual(objectFromOldGroup.objects[1], objectFromNewGroup.objects[1]);
 
       // delete `objects` arrays, since `assertHashEqual` fails to compare them for equality
       delete objectFromOldGroup.objects;


### PR DESCRIPTION
#2095 @chrisrickard reported a problem of `group.toObject`. This PR would fix it.
There are two fixed points.

1. If toObject copied delegatedProperties, it affects to grouped objects at initialization (https://github.com/kangax/fabric.js/blob/master/src/shapes/group.class.js#L72).
I removed delegatedProperties at toObject function, but it is also possible to fix by changing group initialization code. I felt that fix at toObject will be better for consistency.

~~2. At toObject, _objects copied normally. However, at initialization, _objects coordinates are updated (https://github.com/kangax/fabric.js/blob/master/src/shapes/group.class.js#L70).
It makes change position of grouped objects.
To fix it, I use _restoreObjectsState, before copying _objects.~~

closes #2119
closes #2095