### PR TITLE
Fix path initialize

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -96,14 +96,7 @@
         this.path = this._parsePath();
       }
 
-      if (typeof options.top === 'undefined') {
-        this.top = null;
-      }
-      if (typeof options.left === 'undefined') {
-        this.left = null;
-      }
-
-      this._setPositionDimensions();
+      this._setPositionDimensions(options);
 
       if (options.sourcePath) {
         this.setSourcePath(options.sourcePath);
@@ -113,7 +106,7 @@
     /**
      * @private
      */
-    _setPositionDimensions: function() {
+    _setPositionDimensions: function(options) {
       var calcDim = this._parseDimensions();
 
       this.minX = calcDim.left;
@@ -121,7 +114,7 @@
       this.width = calcDim.width;
       this.height = calcDim.height;
 
-      if (this.left === null) {
+      if (typeof options.left === 'undefined') {
         this.left = calcDim.left + (this.originX === 'center'
           ? this.width / 2
           : this.originX === 'right'
@@ -129,7 +122,7 @@
             : 0);
       }
 
-      if (this.top === null) {
+      if (typeof options.top === 'undefined') {
         this.top = calcDim.top + (this.originY === 'center'
           ? this.height / 2
           : this.originY === 'bottom'

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -105,6 +105,7 @@
 
     /**
      * @private
+     * @param {Object} options Options object
      */
     _setPositionDimensions: function(options) {
       var calcDim = this._parseDimensions();

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -96,6 +96,13 @@
         this.path = this._parsePath();
       }
 
+      if (typeof options.top === 'undefined') {
+        this.top = null;
+      }
+      if (typeof options.left === 'undefined') {
+        this.left = null;
+      }
+
       this._setPositionDimensions();
 
       if (options.sourcePath) {
@@ -114,20 +121,21 @@
       this.width = calcDim.width;
       this.height = calcDim.height;
 
-      calcDim.left += this.originX === 'center'
-        ? this.width / 2
-        : this.originX === 'right'
-          ? this.width
-          : 0;
+      if (this.left === null) {
+        this.left = calcDim.left + (this.originX === 'center'
+          ? this.width / 2
+          : this.originX === 'right'
+            ? this.width
+            : 0);
+      }
 
-      calcDim.top += this.originY === 'center'
-        ? this.height / 2
-        : this.originY === 'bottom'
-          ? this.height
-          : 0;
-
-      this.top = this.top || calcDim.top;
-      this.left = this.left || calcDim.left;
+      if (this.top === null) {
+        this.top = calcDim.top + (this.originY === 'center'
+          ? this.height / 2
+          : this.originY === 'bottom'
+            ? this.height
+            : 0);
+      }
 
       this.pathOffset = this.pathOffset || {
         x: this.minX + this.width / 2,

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -75,6 +75,14 @@
     });
   });
 
+  asyncTest('initialize', function() {
+    var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', { top: 0 });
+
+    equal(path.left, 100);
+    equal(path.top, 0);
+    start();
+  });
+
   asyncTest('toString', function() {
     makePathObject(function(path) {
       ok(typeof path.toString == 'function');


### PR DESCRIPTION
At #2095, there are two problems inside.
First problem comes from group.toObject would be fixed by #2101.
Second problem comes from path.initialize would be fixed by this PR.

At initialization, option.top = 0, then, path.top is updated by _setPositionDimensions, which makes path.top to nonzero, sometime.

To avoid updating by _setPositionDimensions, ~~this PR set path.top=null if option.top is undefined.
In _setPositionDimensions, judge updating path.top by path.top is null or not.~~ set path.top by option.top is undefined or not.