### PR TITLE
Make .canvas property always present

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -122,6 +122,7 @@
       if (object) {
         this._objects.push(object);
         object.group = this;
+        object._set('canvas', this.canvas);
       }
       // since _restoreObjectsState set objects inactive
       this.forEachObject(this._setObjectActive, this);
@@ -163,6 +164,7 @@
      */
     _onObjectAdded: function(object) {
       object.group = this;
+      object._set('canvas', this.canvas);
     },
 
     /**
@@ -194,7 +196,7 @@
      * @private
      */
     _set: function(key, value) {
-      if (key in this.delegatedProperties) {
+      if (key in this.delegatedProperties || key === 'canvas') {
         var i = this._objects.length;
         while (i--) {
           this._objects[i].set(key, value);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -756,7 +756,7 @@
      */
     _onObjectAdded: function(obj) {
       this.stateful && obj.setupState();
-      obj.canvas = this;
+      obj._set('canvas', this);
       obj.setCoords();
       this.fire('object:added', { target: obj });
       obj.fire('added');

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -479,6 +479,25 @@ test('toObject without default values', function() {
     equal(group.insertAt(rect1, 2), group, 'should be chainable');
   });
 
+  test('canvas property propagation', function() {
+    var g1 = makeGroupWith4Objects(),
+        g2 = makeGroupWith4Objects(),
+        rect1 = new fabric.Rect(),
+        rect2 = new fabric.Rect(),
+        group1 = new fabric.Group([g1]);
+
+    group1.add(g2);
+    group1.insertAt(rect1, 0);
+    g2.insertAt(rect2, 0);
+
+    canvas.add(group1);
+    equal(g2.canvas, canvas);
+    equal(g2._objects[3].canvas, canvas);
+    equal(g1.canvas, canvas);
+    equal(g1._objects[3].canvas, canvas);
+    equal(rect2.canvas, canvas);
+    equal(rect1.canvas, canvas);
+  });
   // asyncTest('cloning group with image', function() {
   //   var rect = new fabric.Rect({ top: 100, left: 100, width: 30, height: 10 }),
   //       img = new fabric.Image(_createImageElement()),


### PR DESCRIPTION
i do not know if adding canvas to delegate properties, because this involves also reading.
anyway setting the canvas with ._set('canvas', value) automatically on object adding, both on canvas and on groups classes, should allow us to have canvas property spread to all objects inside ( in group and group of groups )