### PR TITLE
fix group.toObject for _objects hasControls

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -211,8 +211,16 @@
      * @return {Object} object representation of an instance
      */
     toObject: function(propertiesToInclude) {
+      // `hasControls` in _objects is always false by `_updateObjectCoords`.
+      // To restore original `hasControls` at `_restoreObjectState`,
+      // we need to save `__origHasControls` property.
+      var objectsPropertiesToInclude = (propertiesToInclude || []).slice();
+      if (objectsPropertiesToInclude.indexOf('__origHasControls') === -1) {
+        objectsPropertiesToInclude.push('__origHasControls');
+      }
+
       return extend(this.callSuper('toObject', propertiesToInclude), {
-        objects: invoke(this._objects, 'toObject', propertiesToInclude)
+        objects: invoke(this._objects, 'toObject', objectsPropertiesToInclude)
       });
     },
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -383,6 +383,23 @@ test('toObject without default values', function() {
     });
   });
 
+  asyncTest('fromObject with destroy', function() {
+    var group = makeGroupWith2Objects();
+    var object0 = group._objects[0];
+    var groupObject = group.toObject( ['hasControls'] );
+
+    fabric.Group.fromObject(groupObject, function(newGroupFromObject) {
+      var newGroupObject0 = newGroupFromObject._objects[0];
+
+      group.destroy();
+      newGroupFromObject.destroy();
+
+      equal(object0.hasControls, newGroupObject0.hasControls);
+
+      start();
+    });
+  });
+
   test('toSVG', function() {
     var group = makeGroupWith2Objects();
     ok(typeof group.toSVG == 'function');


### PR DESCRIPTION
`hasControls` in _objects is always false by `_updateObjectCoords`.
To restore original `hasControls` at `_restoreObjectState`,
we need to save `__origHasControls` property.