### PR TITLE
Fix unit test for image

### DIFF
--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -155,8 +155,6 @@
     createImageObject(function(image) {
       equal(image.crossOrigin, '', 'initial crossOrigin value should be set');
 
-      start();
-
       var elImage = _createImageElement();
       elImage.crossOrigin = 'anonymous';
       image = new fabric.Image(elImage);


### PR DESCRIPTION
In Google Chrome, there is a unit test error, which comes from start() call twice in asyncTest.
This PR removes first start().

![ws000018](https://cloud.githubusercontent.com/assets/11169954/7363178/fea46590-edb0-11e4-8e3d-5bba7797bf7d.png)