### PR TITLE
Don't import elements declared within `<metadata>`

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -541,7 +541,7 @@
       var elements = descendants.filter(function(el) {
         reViewBoxTagNames.test(el.tagName) && addVBTransform(el, 0, 0);
         return reAllowedSVGTagNames.test(el.tagName) &&
-              !hasAncestorWithNodeName(el, /^(?:pattern|defs|symbol)$/); // http://www.w3.org/TR/SVG/struct.html#DefsElement
+              !hasAncestorWithNodeName(el, /^(?:pattern|defs|symbol|metadata)$/); // http://www.w3.org/TR/SVG/struct.html#DefsElement
       });
 
       if (!elements || (elements && !elements.length)) {


### PR DESCRIPTION
Some SVG files declare elements inside of the metadata block. Don’t import them.