### PR TITLE
node.js segmentation fault when image couldn't be loaded

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -71,10 +71,12 @@
 
   fabric.util.loadImage = function(url, callback, context) {
     function createImageAndCallBack(data) {
-      img.src = new Buffer(data, 'binary');
-      // preserving original url, which seems to be lost in node-canvas
-      img._src = url;
-      callback && callback.call(context, img);
+      if (data) {
+        img.src = new Buffer(data, 'binary');
+        // preserving original url, which seems to be lost in node-canvas
+        img._src = url;
+        callback && callback.call(context, img);
+      }
     }
     var img = new Image();
     if (url && (url instanceof Buffer || url.indexOf('data') === 0)) {

--- a/src/node.js
+++ b/src/node.js
@@ -50,6 +50,7 @@
       else {
         fabric.log(err.message);
       }
+      callback(null);
     });
 
     req.end();
@@ -76,6 +77,10 @@
         // preserving original url, which seems to be lost in node-canvas
         img._src = url;
         callback && callback.call(context, img);
+      }
+      else {
+        img = null;
+        callback && callback.call(context, null, true);
       }
     }
     var img = new Image();

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -24,6 +24,8 @@
     ? require("path").join(__dirname, '../fixtures/', 'very_large_image.jpg')
     : getAbsolutePath('../fixtures/very_large_image.jpg');
 
+  var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
+
   test('fabric.util.toFixed', function(){
     ok(typeof fabric.util.toFixed == 'function');
 
@@ -455,6 +457,23 @@
 
     setTimeout(function() {
       ok(callbackInvoked, 'callback should be invoked');
+      start();
+    }, 1000);
+  });
+
+
+  asyncTest('fabric.util.loadImage with url for a non exsiting image', function() {
+    var callbackInvoked = false;
+    var hadError = false;
+
+    fabric.util.loadImage(IMG_URL_NON_EXISTING, function(img, error) {
+      callbackInvoked = true;
+      hadError = error;
+    });
+
+    setTimeout(function() {
+      ok(callbackInvoked, 'callback should be invoked');
+      equal(hadError, true, 'callback should be invoked with error set to true');
       start();
     }, 1000);
   });


### PR DESCRIPTION
Don't create image Buffer based on `data` when `data` is empty.
It happens when response status code of accessed image is other than 200.

Should also fix #1355

Example of crashing code:
```
var fabric = require('fabric').fabric;

fabric.util.loadImage('http://www.google.com/non-existing', function() {
  console.log('Loaded');
});
```