### PR TITLE
Remove build.js from .npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,3 @@ dist/fabric.min.js
 dist/fabric.min.js.gz
 .DS_Store
 HEADER.js
-build.js


### PR DESCRIPTION
I would like a way to have a reproducible custom version of Fabric.js in my project.  Your git tags (thanks for moving to SemVer!) and `build.js` file go a long way to making this possible, but the `build.js` file being in the `.npmignore` list excludes it from npm installations which prevents me from being able to do this during my build process.

If there's no conflict, it would be great if we could include the `build.js` file in npm installations.

Thanks!