### PR TITLE
Only renderAll() while moving objects if renderOnAddRemove is true

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1368,7 +1368,8 @@
     sendToBack: function (object) {
       removeFromArray(this._objects, object);
       this._objects.unshift(object);
-      return this.renderAll && this.renderAll();
+      this.renderOnAddRemove && this.renderAll();
+      return this;
     },
 
     /**
@@ -1380,7 +1381,8 @@
     bringToFront: function (object) {
       removeFromArray(this._objects, object);
       this._objects.push(object);
-      return this.renderAll && this.renderAll();
+      this.renderOnAddRemove && this.renderAll();
+      return this;
     },
 
     /**
@@ -1399,7 +1401,7 @@
 
         removeFromArray(this._objects, object);
         this._objects.splice(newIdx, 0, object);
-        this.renderAll && this.renderAll();
+        this.renderOnAddRemove && this.renderAll();
       }
       return this;
     },
@@ -1449,7 +1451,7 @@
 
         removeFromArray(this._objects, object);
         this._objects.splice(newIdx, 0, object);
-        this.renderAll && this.renderAll();
+        this.renderOnAddRemove && this.renderAll();
       }
       return this;
     },
@@ -1493,7 +1495,8 @@
     moveTo: function (object, index) {
       removeFromArray(this._objects, object);
       this._objects.splice(index, 0, object);
-      return this.renderAll && this.renderAll();
+      this.renderOnAddRemove && this.renderAll();
+      return this;
     },
 
     /**


### PR DESCRIPTION
Currently all methods that move objects to different indexes check the
existence of the renderAll method which i believe is supposed to be
checking if renderOnAddRemove is true
