### PR TITLE
fix selection itext transformatrix

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -328,6 +328,7 @@
         ctx.save();
         ctx.transform.apply(ctx, this.canvas.viewportTransform);
         this.transform(ctx);
+        this.transformMatrix && ctx.transform.apply(ctx, this.transformMatrix);
       }
       else {
         ctx = this.ctx;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1194048/7509634/9b634368-f493-11e4-971a-51ddfa31960d.png)


do not expect selection by cursor to work outside bounding box.

closes #2122