### PR TITLE
IText 'getSelectionStyles' Bug Fix

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -20639,6 +20639,10 @@ fabric.Image.filters.BaseFilter = fabric.util.createClass(/** @lends fabric.Imag
      */
     getSelectionStyles: function(startIndex, endIndex) {
 
+      if (! this.getSelectedText().length) {
+        return { };
+      }
+
       if (arguments.length === 2) {
         var styles = [ ];
         for (var i = startIndex; i < endIndex; i++) {


### PR DESCRIPTION
This fixes a bug where if you select a portion of text within an IText object and select another element without clearing the text selection it still returns the old selection's styles when getSelectionStyles is called.

For instance, if you have a bold button which tells whether or not the currently selected text is bold, if you highlight text, make it bold, click off the object and click back on it - it will still say the selected text is bold when there is no selected text.

If you have trouble replicating the bug it give me a shout,

Thanks!! :)