### PR TITLE
Fix restore stroke gradient from object

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -699,6 +699,9 @@
       if (options.fill && options.fill.colorStops && !(options.fill instanceof fabric.Gradient)) {
         this.set('fill', new fabric.Gradient(options.fill));
       }
+      if (options.stroke && options.stroke.colorStops && !(options.stroke instanceof fabric.Gradient)) {
+        this.set('stroke', new fabric.Gradient(options.stroke));
+      }
     },
 
     /**
@@ -1111,7 +1114,7 @@
         return;
       }
 
-      if (!this.shadow.affectStroke) {
+      if (this.shadow && !this.shadow.affectStroke) {
         this._removeShadow(ctx);
       }
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -64,6 +64,13 @@
     var rect = fabric.Rect.fromObject(REFERENCE_RECT);
     ok(rect instanceof fabric.Rect);
     deepEqual(rect.toObject(), REFERENCE_RECT);
+
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.fill = {"type":"linear","coords":{"x1":0,"y1":0,"x2":200,"y2":0},"colorStops":[{"offset":"0","color":"rgb(255,0,0)","opacity":1},{"offset":"1","color":"rgb(0,0,255)","opacity":1}],"offsetX":0,"offsetY":0};
+    expectedObject.stroke = {"type":"linear","coords":{"x1":0,"y1":0,"x2":200,"y2":0},"colorStops":[{"offset":"0","color":"rgb(255,0,0)","opacity":1},{"offset":"1","color":"rgb(0,0,255)","opacity":1}],"offsetX":0,"offsetY":0};
+    rect = fabric.Rect.fromObject(expectedObject);
+    ok(rect.fill instanceof fabric.Gradient);
+    ok(rect.stroke instanceof fabric.Gradient);
   });
 
   test('fabric.Rect.fromElement', function() {


### PR DESCRIPTION
The initGradient method was missing the stroke object

includes @sapics fix #2181 

closes #2181