### PR TITLE
Improve Object selection - Fix Line shape toObject

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -790,6 +790,7 @@
      */
     _checkTarget: function(e, obj, pointer) {
       if (obj &&
+          obj.selectable &&
           obj.visible &&
           obj.evented &&
           this.containsPoint(e, obj)){

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -202,7 +202,12 @@
      * @return {Object} object representation of an instance
      */
     toObject: function(propertiesToInclude) {
-      return extend(this.callSuper('toObject', propertiesToInclude), this.calcLinePoints());
+      return extend(this.callSuper('toObject', propertiesToInclude), {
+        x1: this.x1,
+        x2: this.x2,
+        y1: this.y1,
+        y2: this.y2
+      });
     },
 
     /**


### PR DESCRIPTION
Let canvas select a selectable objects that exists under a none-selectable Object by only processing selectable objects