### PR TITLE
Fix duplication of line styles when inserting a newline in IText

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -668,7 +668,7 @@
         var numericLine = parseInt(line, 10);
         if (numericLine > lineIndex) {
           this.styles[numericLine + offset] = clonedStyles[numericLine];
-          if(!clonedStyles[numericLine - offset]) {
+          if (!clonedStyles[numericLine - offset]) {
             delete this.styles[numericLine];
           }
         }

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -557,12 +557,8 @@
         this.styles[lineIndex + 1] = { };
       }
 
-      var currentCharStyle = { },
+      var currentCharStyle = this.styles[lineIndex][charIndex - 1],
           newLineStyles = { };
-
-      if(this.styles[lineIndex] && this.styles[lineIndex][charIndex - 1]) {
-          currentCharStyle = this.styles[lineIndex][charIndex - 1];
-      }
 
       // if there's nothing after cursor,
       // we clone current char style onto the next (otherwise empty) line

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -274,15 +274,6 @@
     equal(iText.text, 't\nt');
   });
 
-  test('insertNewlineStyleObject', function() {
-    var iText = new fabric.IText('test\n');
-
-    equal(typeof iText.insertNewlineStyleObject, 'function');
-
-    iText.insertNewlineStyleObject(0, 4, true);
-    deepEqual(iText.styles, { '1': { '0': { } } });
-  });
-
   test('shiftLineStyles', function() {
     var iText = new fabric.IText('test\ntest\ntest', {
       styles: {


### PR DESCRIPTION
When copying styles from oldStyles[lineIndex] to newStyles[lineIndex + 1] check if previous line was empty (and thus not iterated over) and if true, delete it.

There is a TODO comment in the function
//TODO: evaluate if delete old style lines with offset -1
but I wasn't sure if that refers to this issue.

Closes #2188