### PR TITLE
Fix insertNewlineStyleObject failing, when lineIndex is not present in style object

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -560,8 +560,8 @@
       var currentCharStyle = { },
           newLineStyles = { };
 
-      if(this.styles[lineIndex] && this.styles[lineIndex][charIndex - 1]) {
-          currentCharStyle = this.styles[lineIndex][charIndex - 1];
+      if (this.styles[lineIndex] && this.styles[lineIndex][charIndex - 1]) {
+        currentCharStyle = this.styles[lineIndex][charIndex - 1];
       }
 
       // if there's nothing after cursor,

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -557,8 +557,12 @@
         this.styles[lineIndex + 1] = { };
       }
 
-      var currentCharStyle = this.styles[lineIndex][charIndex - 1],
+      var currentCharStyle = { },
           newLineStyles = { };
+
+      if(this.styles[lineIndex] && this.styles[lineIndex][charIndex - 1]) {
+          currentCharStyle = this.styles[lineIndex][charIndex - 1];
+      }
 
       // if there's nothing after cursor,
       // we clone current char style onto the next (otherwise empty) line
@@ -668,6 +672,9 @@
         var numericLine = parseInt(line, 10);
         if (numericLine > lineIndex) {
           this.styles[numericLine + offset] = clonedStyles[numericLine];
+          if(!clonedStyles[numericLine - offset]) {
+            delete this.styles[numericLine];
+          }
         }
       }
       //TODO: evaluate if delete old style lines with offset -1

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -672,9 +672,6 @@
         var numericLine = parseInt(line, 10);
         if (numericLine > lineIndex) {
           this.styles[numericLine + offset] = clonedStyles[numericLine];
-          if(!clonedStyles[numericLine - offset]) {
-            delete this.styles[numericLine];
-          }
         }
       }
       //TODO: evaluate if delete old style lines with offset -1

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -274,6 +274,51 @@
     equal(iText.text, 't\nt');
   });
 
+  test('insertNewlineStyleObject', function() {
+    var iText = new fabric.IText('test\n');
+
+    equal(typeof iText.insertNewlineStyleObject, 'function');
+
+    iText.insertNewlineStyleObject(0, 4, true);
+    deepEqual(iText.styles, { '1': { '0': { } } });
+  });
+
+  test('shiftLineStyles', function() {
+    var iText = new fabric.IText('test\ntest\ntest', {
+      styles: {
+        '1': {
+          '0': { 'fill': 'red' },
+          '1': { 'fill': 'red' },
+          '2': { 'fill': 'red' },
+          '3': { 'fill': 'red' }
+        }
+      }
+    });
+
+    equal(typeof iText.shiftLineStyles, 'function');
+
+    iText.shiftLineStyles(0, +1);
+    deepEqual(iText.styles, {
+      '2': {
+        '0': { 'fill': 'red' },
+        '1': { 'fill': 'red' },
+        '2': { 'fill': 'red' },
+        '3': { 'fill': 'red' }
+      }
+    });
+
+    iText.shiftLineStyles(0, -1);
+    deepEqual(iText.styles, {
+      '1': {
+        '0': { 'fill': 'red' },
+        '1': { 'fill': 'red' },
+        '2': { 'fill': 'red' },
+        '3': { 'fill': 'red' }
+      }
+    });
+
+  });
+
   test('selectWord', function() {
     var iText = new fabric.IText('test foo bar-baz\nqux');
 

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -283,42 +283,6 @@
     deepEqual(iText.styles, { '1': { '0': { } } });
   });
 
-  test('shiftLineStyles', function() {
-    var iText = new fabric.IText('test\ntest\ntest', {
-      styles: {
-        '1': {
-          '0': { 'fill': 'red' },
-          '1': { 'fill': 'red' },
-          '2': { 'fill': 'red' },
-          '3': { 'fill': 'red' }
-        }
-      }
-    });
-
-    equal(typeof iText.shiftLineStyles, 'function');
-
-    iText.shiftLineStyles(0, +1);
-    deepEqual(iText.styles, {
-      '2': {
-        '0': { 'fill': 'red' },
-        '1': { 'fill': 'red' },
-        '2': { 'fill': 'red' },
-        '3': { 'fill': 'red' }
-      }
-    });
-
-    iText.shiftLineStyles(0, -1);
-    deepEqual(iText.styles, {
-      '1': {
-        '0': { 'fill': 'red' },
-        '1': { 'fill': 'red' },
-        '2': { 'fill': 'red' },
-        '3': { 'fill': 'red' }
-      }
-    });
-
-  });
-
   test('selectWord', function() {
     var iText = new fabric.IText('test foo bar-baz\nqux');
 


### PR DESCRIPTION
currentCharStyle was assigned the value of this.styles[lineIndex][charIndex - 1]. This fails if there is no lineIndex object in this.styles. This assigns an empty object to currentCharStyle by default and only assigns the value if it's present.

Closes #2189