### PR TITLE
Add a bool to force cache clear on next render

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -582,7 +582,7 @@
         }
         this.styles[lineIndex + 1] = newLineStyles;
       }
-      this._clearCache();
+      this._forceClearCache = true;
     },
 
     /**
@@ -612,7 +612,7 @@
 
       this.styles[lineIndex][charIndex] =
         style || clone(currentLineStyles[charIndex - 1]);
-      this._clearCache();
+      this._forceClearCache = true;
     },
 
     /**

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -579,7 +579,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
     this._removeExtraneousStyles();
 
-    this._clearCache();
     this.canvas && this.canvas.renderAll();
 
     this.setCoords();

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -283,7 +283,7 @@
         }
       }
       /* not included in _extendStyles to avoid clearing cache more than once */
-      this._clearCache();
+      this._forceClearCache = true;
       return this;
     },
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -682,6 +682,10 @@
      */
     _shouldClearCache: function() {
       var shouldClear = false;
+      if (this._forceClearCache) {
+        this._forceClearCache = false;
+        return true;
+      }
       for (var prop in this._dimensionAffectingProps) {
         if (this['__' + prop] !== this[prop]) {
           this['__' + prop] = this[prop];


### PR DESCRIPTION
Issue #2201 made me found out the bug i was searching for.
Clearing cache is not enough, because dimension of text where not recalculated if cache clearing was not detected by ```_shouldClearCache()``` method.

Adding a boolean that force cache clearing solves this problems, also avoids to clear cache too many time for one rendering

closes #2201 
