### PR TITLE
image.class.js not properly calling _initConfig when initializing

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -451,9 +451,10 @@
      * called by the constructor.
      * @private
      * @param {HTMLImageElement|String} element The element representing the image
+     * @param {Object} [options] Options object
      */
-    _initElement: function(element) {
-      this.setElement(fabric.util.getById(element));
+    _initElement: function(element, options) {
+      this.setElement(fabric.util.getById(element), null, options);
       fabric.util.addClass(this.getElement(), fabric.Image.CSS_CANVAS);
     },
 


### PR DESCRIPTION
There was a small bug introduced in https://github.com/kangax/fabric.js/commit/ed5b1b66b05fe2f2433cce8da6340d2ebd27dc3b which didn't carry initialization options through.