### PR TITLE
Make IText support accent-based languages

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -478,6 +478,8 @@
       this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
       this.hiddenTextarea = null;
 
+      this.latestKeyCode = null;
+
       this.abortCursorAnimation();
       this._restoreEditingProps();
       this._currentCursorOpacity = 0;
@@ -502,12 +504,12 @@
     /**
      * @private
      */
-    _removeCharsFromTo: function(start, end) {
+    _removeCharsFromTo: function(start, end, noTextareaUpdate) {
       while (end !== start) {
         this._removeSingleCharAndStyle(start + 1);
         end--;
       }
-      this.setSelectionStart(start);
+      this.setSelectionStart(start, noTextareaUpdate);
     },
 
     _removeSingleCharAndStyle: function(index) {
@@ -523,18 +525,20 @@
     /**
      * Inserts a character where cursor is (replacing selection if one exists)
      * @param {String} _chars Characters to insert
+     * @param {Boolean} useCopiedStyle Use copied style or not
+     * @param {Boolean} noTextareaUpdate True if no need to update textarea
      */
-    insertChars: function(_chars, useCopiedStyle) {
+    insertChars: function(_chars, useCopiedStyle, noTextareaUpdate) {
       if (this.selectionEnd - this.selectionStart > 1) {
-        this._removeCharsFromTo(this.selectionStart, this.selectionEnd);
-        this.setSelectionEnd(this.selectionStart);
+        this._removeCharsFromTo(this.selectionStart, this.selectionEnd, noTextareaUpdate);
+        this.setSelectionEnd(this.selectionStart, noTextareaUpdate);
       }
       var isEndOfLine = this.text[this.selectionStart] === '\n';
       this.text = this.text.slice(0, this.selectionStart) +
                   _chars + this.text.slice(this.selectionEnd);
       this.insertStyleObjects(_chars, isEndOfLine, useCopiedStyle);
-      this.setSelectionStart(this.selectionStart + _chars.length);
-      this.setSelectionEnd(this.selectionStart);
+      this.setSelectionStart(this.selectionStart + _chars.length, noTextareaUpdate);
+      this.setSelectionEnd(this.selectionStart, noTextareaUpdate);
 
       this.canvas && this.canvas.renderAll();
 

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -478,8 +478,6 @@
       this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
       this.hiddenTextarea = null;
 
-      this.latestKeyCode = null;
-
       this.abortCursorAnimation();
       this._restoreEditingProps();
       this._currentCursorOpacity = 0;
@@ -527,18 +525,28 @@
      * @param {String} _chars Characters to insert
      * @param {Boolean} useCopiedStyle Use copied style or not
      * @param {Boolean} noTextareaUpdate True if no need to update textarea
+     * @param {Object} range Range discriptor {start: {Number}, end: {Number}}
      */
-    insertChars: function(_chars, useCopiedStyle, noTextareaUpdate) {
-      if (this.selectionEnd - this.selectionStart > 1) {
-        this._removeCharsFromTo(this.selectionStart, this.selectionEnd, noTextareaUpdate);
-        this.setSelectionEnd(this.selectionStart, noTextareaUpdate);
+    insertChars: function(_chars, useCopiedStyle, noTextareaUpdate, range) {
+      var rangeStart,
+          rangeEnd;
+      //use range instead of selection if given
+      rangeStart = range ? range.start : this.selectionStart;
+      rangeEnd = range ? range.end : this.selectionEnd;
+
+      if (rangeStart - rangeEnd > 1) {
+        this._removeCharsFromTo(rangeStart, rangeEnd, noTextareaUpdate);
       }
-      var isEndOfLine = this.text[this.selectionStart] === '\n';
-      this.text = this.text.slice(0, this.selectionStart) +
-                  _chars + this.text.slice(this.selectionEnd);
+      var isEndOfLine = this.text[rangeStart] === '\n';
+      this.text = this.text.slice(0, rangeStart) +
+                  _chars + this.text.slice(rangeEnd);
       this.insertStyleObjects(_chars, isEndOfLine, useCopiedStyle);
-      this.setSelectionStart(this.selectionStart + _chars.length, noTextareaUpdate);
-      this.setSelectionEnd(this.selectionStart, noTextareaUpdate);
+
+      //when using range, no need to touch selection
+      if (!range) {
+        this.setSelectionEnd(rangeStart + _chars.length, noTextareaUpdate);
+        this.setSelectionStart(rangeStart + _chars.length, noTextareaUpdate);
+      }
 
       this.canvas && this.canvas.renderAll();
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -69,7 +69,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this[this._ctrlKeysMap[e.keyCode]](e);
     }
     else {
-      this.latestKeyCode = e.which;
       return;
     }
     e.stopImmediatePropagation();
@@ -162,19 +161,17 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         oldVal = this.text,
         oLen = oldVal.length,
         nLen = newVal.length,
+        selectionStart = this.hiddenTextarea.selectionStart,
         head,
         tail,
         i;
 
     //scan the whole contents from both begin and end to
     //extract the changes
-    if (newVal.replace(/\ /g, '') === oldVal.replace(/\ /g, '')) {
-      return;
-    }
 
     //find 'start', which indicates the **length** of the changed part before
     //the changes
-    for (i = 0; i < oLen; i++) {
+    for (i = 0; i < selectionStart - 1; i++) {
       if (newVal[i] !== oldVal[i]) {
         break;
       }
@@ -190,9 +187,12 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
     tail = i - 1;
 
-    this.setSelectionStart(head, true);
-    this.setSelectionEnd(oLen - tail, true);
-    this.insertChars(newVal.slice(head, nLen - tail), false, true);
+    this.insertChars(newVal.slice(head, nLen - tail), false, true, {
+      start: head,
+      end: oLen - tail
+    });
+    this.setSelectionStart(this.hiddenTextarea.selectionStart, true);
+    this.setSelectionEnd(this.hiddenTextarea.selectionEnd, true);
   },
 
   /**

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -177,7 +177,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   /**
    * Handles input event
    */
-  onInput: function(){
+  onInput: function() {
     var newVal = this.hiddenTextarea.value,
         oldVal = this.text,
         oLen = oldVal.length,
@@ -192,19 +192,23 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       //daed keys will produce unpredictable results
       //need to scan the whole contents from both begin and end to
       //extract the changes
-      if(newVal.replace(/\ /g, '') === oldVal.replace(/\ /g, '')) {
+      if (newVal.replace(/\ /g, '') === oldVal.replace(/\ /g, '')) {
         return;
       }
 
       //start
       for (i = 0; i < oLen; i++) {
-        if (newVal[i] !== oldVal[i]) break;
+        if (newVal[i] !== oldVal[i]) {
+          break;
+        }
       }
       head = i;
 
       //end
       for (i = 1; i <= nLen; i++) {
-        if (newVal[nLen - i] !== oldVal[oLen - i]) break;
+        if (newVal[nLen - i] !== oldVal[oLen - i]) {
+          break;
+        }
       }
       tail = i - 1;
 
@@ -213,7 +217,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.insertChars(newVal.slice(head, nLen - tail), false, true);
     }
   },
-
 
   /**
    * Gets start offset of a selection

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -8,11 +8,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
     this.hiddenTextarea.style.cssText = 'position: fixed; bottom: 20px; left: 0px; opacity: 0;'
-                                        + ' width: 0px; height: 0px; z-index: -999;';
+                                        + ' width: 0; height: 0; z-index: -999;';
     fabric.document.body.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
-    fabric.util.addListener(this.hiddenTextarea, 'keypress', this.onKeyPress.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'copy', this.copy.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'paste', this.paste.bind(this));
@@ -49,13 +48,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     65: 'selectAll',
     88: 'cut'
   },
-
-  /**
-   * @private
-   */
-  _deadKeys: [
-    229
-  ],
 
   onClick: function() {
     // No need to trigger click event here, focus is enough to have the keyboard appear on Android
@@ -136,6 +128,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     if (copiedText) {
       this.insertChars(copiedText, true);
     }
+    e.stopPropagation();
   },
 
   /**
@@ -161,20 +154,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   },
 
   /**
-   * Handles keypress event
-   * @param {Event} e Event object
-   */
-  onKeyPress: function(e) {
-    if (!this.isEditing || e.metaKey || e.ctrlKey) {
-      return;
-    }
-    if (e.which !== 0) {
-      this.insertChars(String.fromCharCode(e.which));
-    }
-    e.stopPropagation();
-  },
-
-  /**
    * Handles input event
    */
   onInput: function() {
@@ -186,36 +165,33 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         tail,
         i;
 
-    //dead key is hit
-    if (this._deadKeys.indexOf(this.latestKeyCode) !== -1) {
-
-      //daed keys will produce unpredictable results
-      //need to scan the whole contents from both begin and end to
-      //extract the changes
-      if (newVal.replace(/\ /g, '') === oldVal.replace(/\ /g, '')) {
-        return;
-      }
-
-      //start
-      for (i = 0; i < oLen; i++) {
-        if (newVal[i] !== oldVal[i]) {
-          break;
-        }
-      }
-      head = i;
-
-      //end
-      for (i = 1; i <= nLen; i++) {
-        if (newVal[nLen - i] !== oldVal[oLen - i]) {
-          break;
-        }
-      }
-      tail = i - 1;
-
-      this.setSelectionStart(head, true);
-      this.setSelectionEnd(oLen - tail, true);
-      this.insertChars(newVal.slice(head, nLen - tail), false, true);
+    //scan the whole contents from both begin and end to
+    //extract the changes
+    if (newVal.replace(/\ /g, '') === oldVal.replace(/\ /g, '')) {
+      return;
     }
+
+    //find 'start', which indicates the **length** of the changed part before
+    //the changes
+    for (i = 0; i < oLen; i++) {
+      if (newVal[i] !== oldVal[i]) {
+        break;
+      }
+    }
+    head = i;
+
+    //find 'tail', which indicates the **length** of the changed part after
+    //the changes
+    for (i = 1; i <= Math.min(nLen - head, oLen - head); i++) {
+      if (newVal[nLen - i] !== oldVal[oLen - i]) {
+        break;
+      }
+    }
+    tail = i - 1;
+
+    this.setSelectionStart(head, true);
+    this.setSelectionEnd(oLen - tail, true);
+    this.insertChars(newVal.slice(head, nLen - tail), false, true);
   },
 
   /**

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -128,7 +128,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     if (copiedText) {
       this.insertChars(copiedText, true);
     }
-    e.stopPropagation();
+    e.stopImmediatePropagation();
+    e.preventDefault();
   },
 
   /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -219,28 +219,28 @@
      * Sets selection start (left boundary of a selection)
      * @param {Number} index Index to set selection start to
      */
-    setSelectionStart: function(index) {
+    setSelectionStart: function(index, noTextareaUpdate) {
       index = Math.max(index, 0);
       if (this.selectionStart !== index) {
         this.fire('selection:changed');
         this.canvas && this.canvas.fire('text:selection:changed', { target: this });
         this.selectionStart = index;
       }
-      this._updateTextarea();
+      !noTextareaUpdate && this._updateTextarea();
     },
 
     /**
      * Sets selection end (right boundary of a selection)
      * @param {Number} index Index to set selection end to
      */
-    setSelectionEnd: function(index) {
+    setSelectionEnd: function(index, noTextareaUpdate) {
       index = Math.min(index, this.text.length);
       if (this.selectionEnd !== index) {
         this.fire('selection:changed');
         this.canvas && this.canvas.fire('text:selection:changed', { target: this });
         this.selectionEnd = index;
       }
-      this._updateTextarea();
+      !noTextareaUpdate && this._updateTextarea();
     },
 
     /**


### PR DESCRIPTION
Hi there, thanks for the awesome library!

Purpose
-----------

This PR is for making IText support accent-based languages IMEs (will fix #2051 ). This feature was on milestone v1.5.1 but removed, not sure if the way I implement this is the desired way, might cause some duplicated works if you guys already have a plan about how to implement this, but I guess it's worth trying :) 

Currently we use this modified version in our desktop webapp projects and it works fine/correctly in both windows and OSX, haven't test it on other platforms yet.

Concerns & Changes
------------

Firstly, the original `keypress` event handler is kept for normal input scenarios, because in order to fully support the accent-based languages a dirty scan must be done to detect the actual changes (detail is explained below). We can skip that if the incoming input action is not accent-based.

This implementation use the fact that input actions in accent-based languages usually
fire `keydown` with keyCode `229` and following event `input`,
records the latest `keyCode` and handle accent-based input separately. Another scenario is that only an `input` event is fired (e.g: user select a character from options) but it will only happens after one or more regular `keydown`, `input` event sequences, in this case the `latestKeyCode` is still `229` so it is covered.

In accent-based input methods, there's no predictable results according to a given keystroke, the length might be `n` characters longer/shorter or even unchanged, the content might be entirely re-written or changed partially, so we need to scan `hiddenTextArea.value` and `this.text` from both sides to extract the 'changed parts' and the range, then apply it on IText.

one major change except the input handling part is:
`hiddenTextArea.value`, `hiddenTextArea.selectionStart` and `hiddenTextArea.selectionEnd` should not be touched during these input actions, otherwise the input process & state of IME will be intercepted. So an additional parameter `noTextAreaUpdate` is added to several methods to determine if the opperation is triggered by accent-based languages input.

One last thing
------------------

To make it works fluently, one additional change has to be done: move the `hiddenTextArea` closer to the belonging `IText`, but since #1990 is already WIP (and almost done), I'll leave this unchanged for now and fix problems caused by the merging in the future (#1990 will break this PR in some edge cases).