### PR TITLE
fix paste of clipboard content

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -114,7 +114,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    */
   paste: function(e) {
     var copiedText = null,
-        clipboardData = this._getClipboardData(e);
+        clipboardData = this._getClipboardData(e),
+        useCopiedStyle;
 
     // Check for backward compatibility with old browsers
     if (clipboardData) {
@@ -122,10 +123,11 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
     else {
       copiedText = this.copiedText;
+      useCopiedStyle = true;
     }
 
     if (copiedText) {
-      this.insertChars(copiedText, true);
+      this.insertChars(copiedText, useCopiedStyle);
     }
   },
 


### PR DESCRIPTION
closes #2270 

use `copiedStyle` only if the pasted content source is `copiedText`.