### PR TITLE
Differing sizes for control points on Object

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -390,6 +390,13 @@
     cornerSize:               12,
 
     /**
+     * Override the size of object's controlling corners (property for each controls width and height)
+     * @type Object
+     * @default
+     */
+    cornerSizeOverrides:      null,
+
+    /**
      * When true, object's controlling corners are rendered as transparent inside (i.e. stroke instead of fill)
      * @type Boolean
      * @default


### PR DESCRIPTION
I have completed a preliminary feature addition for this in the related branch. I want to use the pull as a platform for conversation as much as review.

I have a need for changing the sizes independantly for the control points on an active object. 

There are obviously some ways I could have done this externally to the library, but on my inspection it seemed quite easy to implement the feature in the mixin for the controls itself.

To achieve this I have:

1. Added a `cornerSizeOverrides` property to `Object`.
2. Where the `cornerSize` is used we now have to look for overrides.
3. Removed all assuptions that the corner bounding box hypotenuse internal angle is 45deg.
4. Removed all assumptions that the width and height of each point are always equal.

This has effected:
- The private `_drawControl` function. 
- The private `_setCornerCoords` function.

Obviously this is a non trivial change and I have tried to maintain exisiting optimisations where they were present. Adding a new property to `Object` I also accept is quite a big change. But it does seem like the most succinct way of achieving my requirement.

Please let me know your thoughts. If this is not acceptable then I will need to implement this another way asap. The code detailed is 'working for me', but I might need some more insight as this is the first time I have really delved into the source code.

Thanks.