### PR TITLE
Itext paste

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -114,18 +114,20 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    */
   paste: function(e) {
     var copiedText = null,
-        clipboardData = this._getClipboardData(e);
+        clipboardData = this._getClipboardData(e),
+        usedCopiedStyle;
 
     // Check for backward compatibility with old browsers
     if (clipboardData) {
-      copiedText = clipboardData.getData('text');
+      copiedText = clipboardData.getData('text').replace(/\r/g, '');
     }
     else {
       copiedText = this.copiedText;
+      usedCopiedStyle = true;
     }
 
     if (copiedText) {
-      this.insertChars(copiedText, true);
+      this.insertChars(copiedText, usedCopiedStyle);
     }
   },
 


### PR DESCRIPTION
replace #2272
closes #2270
closes #2255 

Check for source of copied text when pasting text, to avoid searching for style and for removing unwanted carriage returns.

Thanks to @jcppman for the style fix