### PR TITLE
Fix itextcopypaste

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -102,8 +102,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       clipboardData.setData('text', selectedText);
     }
 
-    this.copiedText = selectedText;
-    this.copiedStyles = this.getSelectionStyles(
+    fabric.copiedText = selectedText;
+    fabric.copiedTextStyle = this.getSelectionStyles(
                           this.selectionStart,
                           this.selectionEnd);
   },
@@ -115,19 +115,21 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   paste: function(e) {
     var copiedText = null,
         clipboardData = this._getClipboardData(e),
-        usedCopiedStyle;
+        useCopiedStyle = true;
 
     // Check for backward compatibility with old browsers
     if (clipboardData) {
       copiedText = clipboardData.getData('text').replace(/\r/g, '');
+      if (!fabric.copiedTextStyle || fabric.copiedText !== copiedText) {
+        useCopiedStyle = false;
+      }
     }
     else {
-      copiedText = this.copiedText;
-      usedCopiedStyle = true;
+      copiedText = fabric.copiedText;
     }
 
     if (copiedText) {
-      this.insertChars(copiedText, usedCopiedStyle);
+      this.insertChars(copiedText, useCopiedStyle);
     }
   },
 


### PR DESCRIPTION
closes #1399 

fix a bug introduce with latest commit in wich style is never used if browser support clipboard.
Moved copiedText and copiedStyle from this.copiedStyle to fabric.copiedStyle to allow copy -> paste of style between different iTexts on canvas ( or different canvases ).
Made a rough check to see if text in clipboard equals to fabric.copiedText so we do not carry on wrong styles around with pasting
Modified insertChar function in a way it inserts one character at time and updating textlines accordingly.
Even if it is not efficent as before, pasting multiple lines or character at the edge of lines looks always correct.
Removed the comment "// TODO: support multiple style insertion if _chars.length > 1" now inserting happens just on _chars.length = 1;