### PR TITLE
Fix shiftclick activegroup

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -284,10 +284,11 @@
           lt;
 
       if (isObjectInGroup) {
-        lt = new fabric.Point(activeGroup.left, activeGroup.top);
-        lt = fabric.util.transformPoint(lt, this.viewportTransform, true);
+        lt = fabric.util.transformPoint(activeGroup.getCenterPoint(), this.viewportTransform, true);
         x -= lt.x;
         y -= lt.y;
+        x /= activeGroup.scaleX;
+        y /= activeGroup.scaleY;
       }
       return { x: x, y: y };
     },
@@ -763,7 +764,7 @@
         return activeGroup;
       }
 
-      var target = this._searchPossibleTargets(e);
+      var target = this._searchPossibleTargets(e, skipGroup);
       this._fireOverOutEvents(target, e);
 
       return target;
@@ -814,15 +815,16 @@
     /**
      * @private
      */
-    _searchPossibleTargets: function(e) {
+    _searchPossibleTargets: function(e, skipGroup) {
 
       // Cache all targets where their bounding box contains point.
       var target,
           pointer = this.getPointer(e, true),
           i = this._objects.length;
       // Do not check for currently grouped objects, since we check the parent group itself.
+      // untill we call this function specifically to search inside the activeGroup
       while (i--) {
-        if (!this._objects[i].group && this._checkTarget(e, this._objects[i], pointer)){
+        if ((!this._objects[i].group || skipGroup) && this._checkTarget(e, this._objects[i], pointer)){
           this.relatedTarget = this._objects[i];
           target = this._objects[i];
           break;


### PR DESCRIPTION
helps #532
close #2170

make possible again too shift click to remove object from activeGroup.
Does not fix ( never worked good ) if group is scaled, rotated.
_normalizePointer requires major rework.

This is anyway a small fix that restore the simple functionality.