### PR TITLE
Some fixes to textbox

### DIFF
--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -10,7 +10,7 @@
      */
     _setSVGTextLineText: function(lineIndex, textSpans, height, textLeftOffset, textTopOffset, textBgRects) {
       if (!this.styles[lineIndex]) {
-        this.callSuper('_setSVGTextLineText',
+        fabric.Text.prototype._setSVGTextLineText.call(this,
           lineIndex, textSpans, height, textLeftOffset, textTopOffset);
       }
       else {

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -92,15 +92,28 @@
         this._set('width', this.dynamicMinWidth);
       }
 
-      // calculate a styleMap that lets us know where styles as, as _textLines is separated by \n and wraps,
-      // but the style object line indices is by \n.
-      this._styleMap = this._generateStyleMap();
-
       // clear cache and re-calculate height
       this._clearCache();
       this.height = this._getTextHeight(ctx);
+      this._setLineWidths();
     },
 
+    /**
+     * set the __lineWidths cache array to support
+     * functions that expect it to be filled
+     * @private
+     */
+    _setLineWidths: function() {
+      for (var i = 0, len = this._textLines.length; i < len; i++) {
+        this.__lineWidths[i] = this.width;
+      }
+    },
+
+    /**
+     * Calculate a styleMap that lets us know where styles as, as _textLines is separated by \n and wraps,
+     * but the style object line indices is by \n.
+     * @private
+     */
     _generateStyleMap: function() {
       var realLineCount     = 0,
           realLineCharCount = 0,
@@ -329,6 +342,8 @@
       var lines = this._wrapText(this.ctx, this.text);
 
       this.ctx.restore();
+      this._textLines = lines;
+      this._styleMap = this._generateStyleMap();
       return lines;
     },
 


### PR DESCRIPTION
Requires to update stylemap from splitTextLines to work with latestchanges of Itext Style.

Fill the cache array of this.__lineWidths that some functions expect to have.

closes #2339 
canvas:
![image](https://cloud.githubusercontent.com/assets/1194048/8746774/dbbfc536-2c8c-11e5-9c3c-a1049940a7c6.png)

svg:
![image](https://cloud.githubusercontent.com/assets/1194048/8746776/e30be4dc-2c8c-11e5-994d-94fd42d6384d.png)
