### PR TITLE
Fix parsing pathgroup dimensions from inner paths

### DIFF
--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -67,7 +67,7 @@
      */
     parseDimensionsFromPaths: function(options) {
       var points, p, xC = [ ], yC = [ ], path, height, width,
-          m = this.transformMatrix;
+          m;
       for (var j = this.paths.length; j--;) {
         path = this.paths[j];
         height = path.height + path.strokeWidth;
@@ -78,6 +78,7 @@
           { x: path.left, y: path.top + height },
           { x: path.left + width, y: path.top + height }
         ];
+        m = this.paths[j].transformMatrix;
         for (var i = 0; i < points.length; i++) {
           p = points[i];
           if (m) {

--- a/test/unit/path_group.js
+++ b/test/unit/path_group.js
@@ -75,9 +75,10 @@
     });
   }
 
-  function getPathGroupObject(callback) {
+  function getPathGroupObject(callback, options) {
+    options = options || { };
     getPathObjects(function(objects) {
-      callback(new fabric.PathGroup(objects));
+      callback(new fabric.PathGroup(objects, options));
     });
   }
 
@@ -94,6 +95,28 @@
       equal(pathGroup.get('type'), 'path-group');
       start();
     });
+  });
+
+  asyncTest('parsingDmensions', function() {
+
+    getPathGroupObject(function(pathGroup) {
+
+      ok(pathGroup instanceof fabric.PathGroup);
+      ok(pathGroup instanceof fabric.Object);
+      //this.assertHasMixin(Enumerable, pathGroup);
+      equal(pathGroup.get('type'), 'path-group');
+      equal(pathGroup.width, 403);
+      equal(pathGroup.height, 303);
+      start();
+    }, {toBeParsed: true});
+  });
+
+  test('parsingDmensionsWithTransformMatrix', function() {
+      var pathA = new fabric.Path("M 100 100 L 300 100 L 200 300 z", {transformMatrix: [2, 0, 0, 2, 0, 0]}),
+          pathB = new fabric.Path("M 200 200 L 100 200 L 400 50 z", {transformMatrix: [3, 0, 0, 3, 0, 0]}),
+          pg = new fabric.PathGroup([pathA, pathB], {toBeParsed: true});
+      equal(pg.width, 1203);
+      equal(pg.height, 603);
   });
 
   asyncTest('getObjects', function() {


### PR DESCRIPTION
now:
![image](https://cloud.githubusercontent.com/assets/1194048/8745373/9500751c-2c7f-11e5-9efc-e6377ad17257.png)

we cannot get the shape dimensions, declared as 100% we are not able to parse the dimensions correctly.

after fix ( i colored white space to show that the padding is actually a defined shape )
![image](https://cloud.githubusercontent.com/assets/1194048/8745347/575f98e6-2c7f-11e5-9642-9f479b4d02cf.png)
