### PR TITLE
Fix text itext code

### DIFF
--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -26,7 +26,7 @@
 
       var chars = this._textLines[lineIndex],
           charOffset = 0,
-          lineLeftOffset = this._getSVGLineLeftOffset(lineIndex) - this.width / 2,
+          lineLeftOffset = this._getLineLeftOffset(this._getLineWidth(this.ctx, lineIndex)) - this.width / 2,
           lineOffset = this._getSVGLineTopOffset(lineIndex),
           heightOfLine = this._getHeightOfLine(this.ctx, lineIndex);
 
@@ -47,13 +47,6 @@
 
         charOffset += charWidth;
       }
-    },
-
-    /**
-     * @private
-     */
-    _getSVGLineLeftOffset: function(lineIndex) {
-      return fabric.util.toFixed(this._getLineLeftOffset(this.__lineWidths[lineIndex]), 2);
     },
 
     /**
@@ -101,8 +94,8 @@
 
       return [
         //jscs:disable validateIndentation
-        '<tspan x="', lineLeftOffset + charOffset, '" y="',
-          lineTopOffset - this.height/2, '" ',
+        '<tspan x="', toFixed(lineLeftOffset + charOffset, NUM_FRACTION_DIGITS), '" y="',
+          toFixed(lineTopOffset - this.height/2, NUM_FRACTION_DIGITS), '" ',
           (styleDecl.fontFamily ? 'font-family="' + styleDecl.fontFamily.replace(/"/g, '\'') + '" ': ''),
           (styleDecl.fontSize ? 'font-size="' + styleDecl.fontSize + '" ': ''),
           (styleDecl.fontStyle ? 'font-style="' + styleDecl.fontStyle + '" ': ''),

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -465,7 +465,7 @@
           charIndex++;
         }
 
-        lineLeftOffset = this._getCachedLineOffset(lineIndex);
+        lineLeftOffset = this._getLineLeftOffset(this._getLineWidth(this.ctx, lineIndex));
       }
       if (typeOfBoundaries === 'cursor') {
         topOffset += (1 - this._fontSizeFraction) * this._getHeightOfLine(this.ctx, lineIndex) / this.lineHeight
@@ -480,16 +480,6 @@
     },
 
     /**
-     * @private
-     */
-    _getCachedLineOffset: function(lineIndex) {
-      var widthOfLine = this._getLineWidth(this.ctx, lineIndex);
-
-      return this.__lineOffsets[lineIndex] ||
-        (this.__lineOffsets[lineIndex] = this._getLineLeftOffset(widthOfLine));
-    },
-
-    /**
      * Renders cursor
      * @param {Object} boundaries
      * @param {CanvasRenderingContext2D} ctx transformed context to draw on
@@ -501,7 +491,7 @@
           charIndex = cursorLocation.charIndex,
           charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
           leftOffset = (lineIndex === 0 && charIndex === 0)
-                    ? this._getCachedLineOffset(lineIndex)
+                    ? this._getLineLeftOffset(this._getLineWidth(ctx, lineIndex))
                     : boundaries.leftOffset;
 
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
@@ -531,7 +521,7 @@
           endLine = end.lineIndex;
 
       for (var i = startLine; i <= endLine; i++) {
-        var lineOffset = this._getCachedLineOffset(i) || 0,
+        var lineOffset = this._getLineLeftOffset(this._getLineWidth(ctx, i)) || 0,
             lineHeight = this._getHeightOfLine(this.ctx, i),
             boxWidth = 0, line = this._textLines[i];
 
@@ -586,7 +576,7 @@
 
       // set proper line offset
       var lineHeight = this._getHeightOfLine(ctx, lineIndex),
-          lineLeftOffset = this._getCachedLineOffset(lineIndex),
+          lineLeftOffset = this._getLineLeftOffset(this._getLineWidth(ctx, lineIndex)),
           prevStyle,
           charsToRender = '';
 
@@ -787,7 +777,7 @@
         }
 
         var lineWidth = this._getLineWidth(ctx, i),
-            lineLeftOffset = this._getCachedLineOffset(i);
+            lineLeftOffset = this._getLineLeftOffset(lineWidth);
 
         if (this.textBackgroundColor) {
           ctx.fillStyle = this.textBackgroundColor;

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -675,7 +675,6 @@
     _clearCache: function() {
       this.__lineWidths = [ ];
       this.__lineHeights = [ ];
-      this.__lineOffsets = [ ];
     },
 
     /**
@@ -931,7 +930,7 @@
         - textTopOffset + height - this.height / 2;
       textSpans.push(
         '<tspan x="',
-          toFixed(textLeftOffset + this._getLineLeftOffset(this.__lineWidths[i]), NUM_FRACTION_DIGITS), '" ',
+          toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
           'y="',
           toFixed(yPos, NUM_FRACTION_DIGITS),
           '" ',
@@ -948,11 +947,11 @@
         '\t\t<rect ',
           this._getFillAttributes(this.textBackgroundColor),
           ' x="',
-          toFixed(textLeftOffset + this._getLineLeftOffset(this.__lineWidths[i]), NUM_FRACTION_DIGITS),
+          toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS),
           '" y="',
           toFixed(height - this.height / 2, NUM_FRACTION_DIGITS),
           '" width="',
-          toFixed(this.__lineWidths[i], NUM_FRACTION_DIGITS),
+          toFixed(this._getLineWidth(this.ctx, i), NUM_FRACTION_DIGITS),
           '" height="',
           toFixed(this._getHeightOfLine(this.ctx, i) / this.lineHeight, NUM_FRACTION_DIGITS),
         '"></rect>\n');

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -143,14 +143,7 @@
         lineIndex = map.line;
         charIndex = map.offset + charIndex;
       }
-
-      if (returnCloneOrEmpty) {
-        return (this.styles[lineIndex] && this.styles[lineIndex][charIndex])
-          ? clone(this.styles[lineIndex][charIndex])
-          : {};
-      }
-
-      return this.styles[lineIndex] && this.styles[lineIndex][charIndex] ? this.styles[lineIndex][charIndex] : null;
+      return this.callSuper('_getStyleDeclaration', lineIndex, charIndex, returnCloneOrEmpty);
     },
 
     /**

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -95,18 +95,6 @@
       // clear cache and re-calculate height
       this._clearCache();
       this.height = this._getTextHeight(ctx);
-      this._setLineWidths();
-    },
-
-    /**
-     * set the __lineWidths cache array to support
-     * functions that expect it to be filled
-     * @private
-     */
-    _setLineWidths: function() {
-      for (var i = 0, len = this._textLines.length; i < len; i++) {
-        this.__lineWidths[i] = this.width;
-      }
     },
 
     /**
@@ -418,7 +406,7 @@
           leftOffset     = 0,
           cursorLocation = this.get2DCursorLocation(),
           lineChars      = this._textLines[cursorLocation.lineIndex].split(''),
-          lineLeftOffset = this._getCachedLineOffset(cursorLocation.lineIndex);
+          lineLeftOffset = this._getLineLeftOffset(this._getLineWidth(this.ctx, cursorLocation.lineIndex));
 
       for (var i = 0; i < cursorLocation.charIndex; i++) {
         leftOffset += this._getWidthOfChar(this.ctx, lineChars[i], cursorLocation.lineIndex, i);


### PR DESCRIPTION
Removed _getSVGLineLeftOffset:
It was just calling getLineLeftOffset and was executing "tofixed, 2" on it.

Later the result was exported to svg, adding another number with arbitrary precision and toFixed was not executed again.

Removed direct access to this.__lineWidths[i].

Removed _getCachedLeftOffset and its caching array:
It was calling getLineLeftOffset and caching the result.
Consider that getLineLeftOffset is actually:

```
    _getLineLeftOffset: function(lineWidth) {
      if (this.textAlign === 'center') {
        return (this.width - lineWidth) / 2;
      }
      if (this.textAlign === 'right') {
        return this.width - lineWidth;
      }
      return 0;
    },
```
no need to cache it.

closes #2366