### PR TITLE
Fix text enter edit on corner

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -126,7 +126,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         return;
       }
 
-      if (this.__lastSelected) {
+      if (this.__lastSelected && !this.__corner) {
         this.enterEditing();
         this.initDelayedCursor(true);
       }

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -28,7 +28,7 @@
           ey = pointer.y,
           xPoints,
           lines;
-
+      this.__corner = 0;
       for (var i in this.oCoords) {
 
         if (!this.isControlVisible(i)) {


### PR DESCRIPTION
Used a lonely variable object.__corner ( i cannot find any reference of it in the libray other than the point in ``` _findTargetCorner ``` where it get assigned) to keep track in the click event if a corner has been clicked.
If we clicked on a corner i'm not gonna enter edit.

closes #2380.

