### PR TITLE
Fix itext paste performance

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -554,11 +554,12 @@
         _char + this.text.slice(this.selectionEnd);
       this._textLines = this._splitTextIntoLines();
       this.insertStyleObjects(_char, isEndOfLine, styleObject);
-      this.setSelectionStart(this.selectionStart + 1);
-      this.setSelectionEnd(this.selectionStart);
+      this.selectionStart += 1;
+      this.selectionEnd = this.selectionStart;
       if (skipUpdate) {
         return;
       }
+      this._updateTextarea();
       this.canvas && this.canvas.renderAll();
       this.setCoords();
       this.fire('changed');


### PR DESCRIPTION
Triggering a hiddenTextarea update twice every char inserted is not a good idea, it slows down everything.

We will trigger it just on last character inserted.

(setSelectionStart and setSelectionEnd they both call this._updateTextarea function that update both cursor position on textarea and the text)

This does not fix the textbox performance issue.