### PR TITLE
Textbox optimization on wraptext

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -558,7 +558,7 @@
         _char + this.text.slice(this.selectionEnd);
       this._textLines = this._splitTextIntoLines();
       this.insertStyleObjects(_char, isEndOfLine, styleObject);
-      this.selectionStart += 1;
+      this.selectionStart += _char.length;
       this.selectionEnd = this.selectionStart;
       if (skipUpdate) {
         return;

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -533,7 +533,11 @@
         this._removeCharsFromTo(this.selectionStart, this.selectionEnd);
         this.setSelectionEnd(this.selectionStart);
       }
-
+      //short circuit for block paste
+      if (!useCopiedStyle && this.isEmptyStyles()) {
+        this.insertChar(_chars, false);
+        return;
+      }
       for (var i = 0, len = _chars.length; i < len; i++) {
         if (useCopiedStyle) {
           style = fabric.copiedTextStyle[i];

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -175,6 +175,11 @@
     _charWidthsCache: { },
 
     /**
+     * @private
+     */
+    __widthOfSpace: [ ],
+
+    /**
      * Constructor
      * @param {String} text Text string
      * @param {Object} [options] Options object
@@ -191,7 +196,6 @@
      */
     _clearCache: function() {
       this.callSuper('_clearCache');
-      this.__maxFontHeights = [ ];
       this.__widthOfSpace = [ ];
     },
 
@@ -1050,7 +1054,6 @@
           maxHeight = currentCharHeight;
         }
       }
-      this.__maxFontHeights[lineIndex] = maxHeight;
       this.__lineHeights[lineIndex] = maxHeight * this.lineHeight * this._fontSizeMult;
       return this.__lineHeights[lineIndex];
     },

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -259,51 +259,45 @@
      * to.
      */
     _wrapLine: function(ctx, text, lineIndex) {
-      var maxWidth  = this.width,
-          lineWidth = this._measureText(ctx, text, lineIndex, 0);
-
-      // first case: does the whole line fit?
-      if (lineWidth < maxWidth) {
-        // if the current line is only one word, we need to keep track of it if it's a large word
-        if (text.indexOf(' ') === -1 && lineWidth > this.dynamicMinWidth) {
-          this.dynamicMinWidth = lineWidth;
-        }
-
-        return [text];
-      }
-
-      // if the whole line doesn't fit, we break it up into words
-      var lines            = [],
+      var lineWidth        = 0,
+          lines            = [],
           line             = '',
           words            = text.split(' '),
+          word             = '',
           offset           = 0,
-          infix            = '',
+          infix            = ' ',
           wordWidth        = 0,
+          infixWidth       = 0,
           largestWordWidth = 0;
 
-      while (words.length > 0) {
-        infix = line === '' ? '' : ' ';
-        wordWidth = this._measureText(ctx, words[0], lineIndex, line.length + infix.length + offset);
-        lineWidth = line === '' ? wordWidth : this._measureText(ctx, line + infix + words[0], lineIndex, offset);
+      for (var i = 0; i < words.length; i++) {
+        word = words[0];
+        wordWidth = this._measureText(ctx, word, lineIndex, offset);
+        offset += word.length;
 
-        if (lineWidth < maxWidth || (line === '' && wordWidth >= maxWidth)) {
-          line += infix + words.shift();
-        }
-        else {
-          offset += line.length + 1; // add 1 because each word is separated by a space
+        lineWidth += infixWidth + wordWidth;
+
+        if (lineWidth >= this.width && line !== '') {
           lines.push(line);
           line = '';
+          lineWidth = wordWidth;
         }
 
-        if (words.length === 0) {
-          lines.push(line);
+        if (line !== '' || word === '') {
+          line += infix;
         }
+        line += word;
+
+        infixWidth = this._measureText(ctx, infix, lineIndex, offset);
+        offset++;
 
         // keep track of largest word
         if (wordWidth > largestWordWidth) {
           largestWordWidth = wordWidth;
         }
       }
+
+      i && lines.push(line);
 
       if (largestWordWidth > this.dynamicMinWidth) {
         this.dynamicMinWidth = largestWordWidth;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -274,7 +274,7 @@
           lineWidth = wordWidth;
         }
 
-        if (line !== '' || word === '') {
+        if (line !== '' || i === 1) {
           line += infix;
         }
         line += word;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -140,6 +140,9 @@
     _getStyleDeclaration: function(lineIndex, charIndex, returnCloneOrEmpty) {
       if (this._styleMap) {
         var map = this._styleMap[lineIndex];
+        if (!map) {
+          return returnCloneOrEmpty ? { } : null;
+        }
         lineIndex = map.line;
         charIndex = map.offset + charIndex;
       }

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -231,20 +231,11 @@
      * @private
      */
     _measureText: function(ctx, text, lineIndex, charOffset) {
-      var width = 0, decl;
+      var width = 0;
       charOffset = charOffset || 0;
 
-      for (var i = 0; i < text.length; i++) {
-        if (this.styles && this.styles[lineIndex] && (decl = this.styles[lineIndex][i + charOffset])) {
-          ctx.save();
-          width += this._applyCharStylesGetWidth(ctx, text[i], lineIndex, i, decl);
-          ctx.restore();
-        }
-        else {
-          // @note: we intentionally pass in an empty style declaration, because if we pass in nothing, it will
-          // retry fetching style declaration
-          width += this._applyCharStylesGetWidth(ctx, text[i], lineIndex, i, {});
-        }
+      for (var i = 0, len = text.length; i < len; i++) {
+        width += this._getWidthOfChar(ctx, text[i], lineIndex, i + charOffset);
       }
 
       return width;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -307,11 +307,12 @@
      * @override
      */
     _splitTextIntoLines: function() {
+      var originalAlign = this.textAlign;
       this.ctx.save();
       this._setTextStyles(this.ctx);
-
+      this.textAlign = 'left';
       var lines = this._wrapText(this.ctx, this.text);
-
+      this.textAlign = originalAlign;
       this.ctx.restore();
       this._textLines = lines;
       this._styleMap = this._generateStyleMap();


### PR DESCRIPTION
I may be wrong, but as of now we are measuring the width of a word with measureText multiple times.

We measure once for sure and the we measure it as many times as many words are in front of it, plus one.

in a sentence like: "the lazy dog jumped over the frog" with a textbox large enough to keep all sentence:

First we measure all line to see if it fits, like a shortcut, that really is not, because the functions called from this._measureText have a per char based logic.
So we are iterating over all char. ( caching the widths or not, this is not the point )

If the line does not fit we proceed as follow:

We measure "the",
Then we add to the line.
Then we measure lazy, we check if line is empty (is not) we measure "the lazy"
Then we add to the line.
Then we measure dog, we check if line is empty (is not) we measure "the lazy dog"
Then we add to the line.
Then we measure jumped, we check if line is empty (is not) we measure "the lazy dog jumped"
and so on....

Because measureText is a performance killer, we should avoid this logic.

This PR is an attempt to fix that behavior.
