### PR TITLE
check for obj.selectable

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -799,6 +799,7 @@
       if (obj &&
           obj.visible &&
           obj.evented &&
+          obj.selectable &&
           this.containsPoint(e, obj)){
         if ((this.perPixelTargetFind || obj.perPixelTargetFind) && !obj.isEditing) {
           var isTransparent = this.isTargetTransparent(obj, pointer.x, pointer.y);


### PR DESCRIPTION
Closes #2460.

Obj.selectable was not checked during checkTarget canvas method.

@kangax ready to merge i think.