### PR TITLE
After rendering a gesture set the origin back to its initial value

### DIFF
--- a/src/mixins/canvas_gestures.mixin.js
+++ b/src/mixins/canvas_gestures.mixin.js
@@ -62,6 +62,8 @@
         this._rotateObjectByAngle(self.rotation, e);
       }
 
+      this._setCenterToOrigin(t.target);
+
       this.renderAll();
       t.action = 'drag';
     },


### PR DESCRIPTION
After completing gesture rendering reset the origin values to prevent unexpected behaviors.

Fixes #2478 

(This is my first PR, so please be gentle if I got anything wrong)
