### PR TITLE
remove Is same color

### DIFF
--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -120,24 +120,6 @@
     },
 
     /**
-     * Sets certain property to a certain value
-     * @param {String} prop
-     * @param {Any} value
-     * @return {fabric.PathGroup} thisArg
-     */
-    _set: function(prop, value) {
-
-      if (prop === 'fill' && value && this.isSameColor()) {
-        var i = this.paths.length;
-        while (i--) {
-          this.paths[i]._set(prop, value);
-        }
-      }
-
-      return this.callSuper('_set', prop, value);
-    },
-
-    /**
      * Returns object representation of this path group
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @return {Object} object representation of an instance
@@ -199,22 +181,6 @@
     toString: function() {
       return '#<fabric.PathGroup (' + this.complexity() +
         '): { top: ' + this.top + ', left: ' + this.left + ' }>';
-    },
-
-    /**
-     * Returns true if all paths in this group are of same color
-     * @return {Boolean} true if all paths are of the same color (`fill`)
-     */
-    isSameColor: function() {
-      var firstPathFill = this.getObjects()[0].get('fill') || '';
-      if (typeof firstPathFill !== 'string') {
-        return false;
-      }
-      firstPathFill = firstPathFill.toLowerCase();
-      return this.getObjects().every(function(path) {
-        var pathFill = path.get('fill') || '';
-        return typeof pathFill === 'string' && (pathFill).toLowerCase() === firstPathFill;
-      });
     },
 
     /**

--- a/test/unit/path_group.js
+++ b/test/unit/path_group.js
@@ -204,24 +204,6 @@
     });
   });
 
-  asyncTest('isSameColor', function() {
-    getPathGroupObject(function(pathGroup) {
-
-      ok(typeof pathGroup.isSameColor == 'function');
-      equal(pathGroup.isSameColor(), true);
-
-      pathGroup.getObjects()[0].set('fill', 'black');
-      equal(pathGroup.isSameColor(), false);
-
-      // case
-      pathGroup.getObjects()[0].set('fill', '#ff5555');
-      pathGroup.getObjects()[1].set('fill', '#FF5555');
-      equal(pathGroup.isSameColor(), true);
-
-      start();
-    });
-  });
-
   asyncTest('set', function() {
     var fillValue = 'rgb(100,200,100)';
     getPathGroupObject(function(pathGroup) {
@@ -231,19 +213,14 @@
 
       ok(typeof pathGroup.set == 'function');
       equal(pathGroup.set('fill', fillValue), pathGroup, 'should be chainable');
-
-      pathGroup.getObjects().forEach(function(path) {
-        equal(path.get('fill'), fillValue);
-      }, this);
-
       equal(pathGroup.get('fill'), fillValue);
 
       // set different color to one of the paths
       pathGroup.getObjects()[1].set('fill', 'black');
       pathGroup.set('fill', 'rgb(255,255,255)');
 
-      equal(pathGroup.getObjects()[0].get('fill'), 'rgb(100,200,100)',
-        'when paths are of different fill, setting fill of a group should not change them');
+      equal(pathGroup.getObjects()[1].get('fill'), 'black',
+        'Changing fill to pathgroup does not influence paths');
 
       pathGroup.getObjects()[1].set('fill', 'red');
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -28,8 +28,6 @@
     'fillRule':                 'nonzero',
     'globalCompositeOperation': 'source-over',
     'transformMatrix':          null,
-    'skewX':                    0,
-    'skewY':                    0,
     'rx':                       0,
     'ry':                       0,
   };
@@ -104,7 +102,6 @@
     elRectWithAttrs.setAttribute('stroke-linecap', 'round');
     elRectWithAttrs.setAttribute('stroke-linejoin', 'bevil');
     elRectWithAttrs.setAttribute('stroke-miterlimit', 5);
-    elRectWithAttrs.setAttribute('skewX', 30);
     //elRectWithAttrs.setAttribute('transform', 'translate(-10,-20) scale(2) rotate(45) translate(5,10)');
 
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
@@ -123,7 +120,6 @@
       strokeLineCap:    'round',
       strokeLineJoin:   'bevil',
       strokeMiterLimit: 5,
-      skewX:            30,
       rx:               11,
       ry:               12
     });


### PR DESCRIPTION
isSameColor was supposed to check if all paths are of the same colors and so replace all paths' fill ( but not stroke ) with a new color.

This was poor implemented not working with:
stroke
gradients
same color written in different notations #000000, black rgb(0,0,0).

Considering that the chance that the pathGroup.set({fill: red}); would behave coherently across different svg are very small, we decided to remove this functionality.