### PR TITLE
Fix object.to data url

### DIFF
--- a/src/mixins/canvas_dataurl_exporter.mixin.js
+++ b/src/mixins/canvas_dataurl_exporter.mixin.js
@@ -57,7 +57,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
    */
   __toDataURL: function(format, quality, cropping) {
 
-    this.renderAll(true);
+    this.renderAll();
 
     var canvasEl = this.upperCanvasEl || this.lowerCanvasEl,
         croppedCanvasEl = this.__getCroppedCanvas(canvasEl, cropping);
@@ -70,9 +70,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
     var data = (fabric.StaticCanvas.supports('toDataURLWithQuality'))
               ? (croppedCanvasEl || canvasEl).toDataURL('image/' + format, quality)
               : (croppedCanvasEl || canvasEl).toDataURL('image/' + format);
-
-    this.contextTop && this.clearContext(this.contextTop);
-    this.renderAll();
 
     if (croppedCanvasEl) {
       croppedCanvasEl = null;
@@ -119,7 +116,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         activeObject = this.getActiveObject(),
         activeGroup = this.getActiveGroup(),
 
-        ctx = this.contextTop || this.contextContainer;
+        ctx = this.contextContainer;
 
     if (multiplier > 1) {
       this.setWidth(scaledWidth).setHeight(scaledHeight);
@@ -152,8 +149,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
     else if (activeObject && this.deactivateAll) {
       this.deactivateAll();
     }
-
-    this.renderAll(true);
 
     var data = this.__toDataURL(format, quality, cropping);
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -853,17 +853,15 @@
      * @return {fabric.Canvas} instance
      * @chainable
      */
-    renderAll: function (allOnTop) {
-      var canvasToDrawOn = this[(allOnTop === true && this.interactive) ? 'contextTop' : 'contextContainer'],
+    renderAll: function () {
+      var canvasToDrawOn = this.contextContainer,
           activeGroup = this.getActiveGroup();
 
       if (this.contextTop && this.selection && !this._groupSelector) {
         this.clearContext(this.contextTop);
       }
 
-      if (!allOnTop) {
-        this.clearContext(canvasToDrawOn);
-      }
+      this.clearContext(canvasToDrawOn);
 
       this.fire('before:render');
 


### PR DESCRIPTION
If toDataUrl is method of statiCanvas is better to render everything on the lower canvas and remove checks for upperCanvas and contextTop.

The real bug is somewhere else:

```
    renderAll: function (allOnTop) {
      var canvasToDrawOn = this[(allOnTop === true && this.interactive) ? 'contextTop' : 'contextContainer'],
          activeGroup = this.getActiveGroup();

      if (this.contextTop && this.selection && !this._groupSelector) {
        this.clearContext(this.contextTop);
      }

      if (!allOnTop) {
        this.clearContext(canvasToDrawOn);
      }
```

we were calling renderAll with allOnTop = true on staticCanvas.
So canvasToDrawOn  was contextContainer.
But later we were cleaning the context just on allOnTop = false.
So both copies of object, scaled and unscaled were on the canvas.
The unscaled one coming from canvas.add() in the object.toDataURL.

really this allOnTop i think is something from the past, now we are not rendering anything on contextTop other than controls sometimes or selectors. i see no reasons to draw all on top.
But not time to check it now.

closes #2474