### PR TITLE
Fix object selectable with shift click and itext mouse cursor click.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -923,7 +923,6 @@
       if (obj &&
           obj.visible &&
           obj.evented &&
-          obj.selectable &&
           this.containsPoint(e, obj)){
         if ((this.perPixelTargetFind || obj.perPixelTargetFind) && !obj.isEditing) {
           var isTransparent = this.isTargetTransparent(obj, pointer.x, pointer.y);

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,7 +13,7 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this.getActiveObject();
-      return e.shiftKey &&
+      return e.shiftKey && target && target.selectable &&
             (this.getActiveGroup() || (activeObject && activeObject !== target))
             && this.selection;
     },


### PR DESCRIPTION
Proper fix for obj.selectable, _checkTarget is to general to take care of selectable.
revert #2466
Closes #2494