### PR TITLE
Applying a mask on a big image gave a corrupted output. 

### DIFF
--- a/src/filters/mask_filter.class.js
+++ b/src/filters/mask_filter.class.js
@@ -57,9 +57,9 @@
       maskCanvasEl.width = maskEl.width;
       maskCanvasEl.height = maskEl.height;
 
-      maskCanvasEl.getContext('2d').drawImage(maskEl, 0, 0, maskEl.width, maskEl.height);
+      maskCanvasEl.getContext('2d').drawImage(maskEl, 0, 0, canvasEl.width, canvasEl.height);
 
-      var maskImageData = maskCanvasEl.getContext('2d').getImageData(0, 0, maskEl.width, maskEl.height),
+      var maskImageData = maskCanvasEl.getContext('2d').getImageData(0, 0, canvasEl.width, canvasEl.height),
           maskData = maskImageData.data;
 
       for (i = 0; i < iLen; i += 4) {

--- a/src/filters/mask_filter.class.js
+++ b/src/filters/mask_filter.class.js
@@ -54,8 +54,8 @@
           i,
           iLen = imageData.width * imageData.height * 4;
 
-      maskCanvasEl.width = maskEl.width;
-      maskCanvasEl.height = maskEl.height;
+      maskCanvasEl.width = canvasEl.width;
+      maskCanvasEl.height = canvasEl.height;
 
       maskCanvasEl.getContext('2d').drawImage(maskEl, 0, 0, canvasEl.width, canvasEl.height);
 


### PR DESCRIPTION
Fixed bug that caused image to be corrupted when a mask was applyed, but only if the image was bigger the mask. Fixes #2531 