### PR TITLE
fixing the "fabric.Object.getSvgFilter is not a function"

### DIFF
--- a/src/mixins/object.svg_export.js
+++ b/src/mixins/object.svg_export.js
@@ -23,7 +23,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
         opacity = typeof this.opacity !== 'undefined' ? this.opacity : '1',
 
         visibility = this.visible ? '' : ' visibility: hidden;',
-        filter = this.getSvgFilter();
+        filter = this.shadow ? 'filter: url(#SVGID_' + this.shadow.id + ');' : '';
 
     return [
       'stroke: ', stroke, '; ',


### PR DESCRIPTION
Hi,

This pull request fixes an issue on a really specific case. When i wanted to export the whole canvas into an SVG if i had interactive text elements in my canvas and changed them, when i tried to convert it into an SVG context, it said "fabric.Object.getSvgFilter is not a function", i think this issue comes since the "this" object is not bound to the actual object, but to the overall system.

Case step by step:

Add a iText object
Edit iText with some text (after creating a dummy).
Export to SVG.

Probably there is a better way to do this? @kangax up to you.