### PR TITLE
RenderAll() changes

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -308,7 +308,8 @@
 
       target.hasBorders = target.transparentCorners = false;
 
-      this._draw(this.contextCache, target);
+      target.render(this.contextCache);
+      target._renderControls(this.contextCache);
 
       target.hasBorders = hasBorders;
       target.transparentCorners = transparentCorners;
@@ -1247,20 +1248,16 @@
      * @param {CanvasRenderingContext2D} ctx Context to render controls on
      */
     drawControls: function(ctx) {
+      ctx.save();
+      ctx.setTransform.apply(ctx, [1, 0, 0, 1, 0, 0]);
       var activeGroup = this.getActiveGroup();
       if (activeGroup) {
-        this._drawGroupControls(ctx, activeGroup);
+        activeGroup._renderControls(ctx);
       }
       else {
         this._drawObjectsControls(ctx);
       }
-    },
-
-    /**
-     * @private
-     */
-    _drawGroupControls: function(ctx, activeGroup) {
-      activeGroup._renderControls(ctx);
+      ctx.restore();
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -749,36 +749,6 @@
     },
 
     /**
-     * Given a context, renders an object on that context
-     * @param {CanvasRenderingContext2D} ctx Context to render object on
-     * @param {fabric.Object} object Object to render
-     * @private
-     */
-    _draw: function (ctx, object) {
-      if (!object) {
-        return;
-      }
-
-      ctx.save();
-      var v = this.viewportTransform;
-      ctx.transform(v[0], v[1], v[2], v[3], v[4], v[5]);
-      if (this._shouldRenderObject(object)) {
-        object.render(ctx);
-      }
-      ctx.restore();
-      if (!this.controlsAboveOverlay) {
-        object._renderControls(ctx);
-      }
-    },
-
-    _shouldRenderObject: function(object) {
-      if (!object) {
-        return false;
-      }
-      return (object !== this.getActiveGroup() || !this.preserveObjectStacking);
-    },
-
-    /**
      * @private
      * @param {fabric.Object} obj Object that was added
      */
@@ -848,14 +818,40 @@
     },
 
     /**
+     * Divides objects in two groups, one to render immediately
+     * and one to render as activeGroup.
+     * return objects to render immediately and pushes the other in the activeGroup.
+     */
+    _chooseObjectsToRender: function() {
+      var activeGroup = this.getActiveGroup(),
+          object, objsToRender = [ ], activeGroupObjects = [ ];
+
+      if (activeGroup && !this.preserveObjectStacking) {
+        for (var i = 0, length = this._objects.length; i < length; i++) {
+          object = this._objects[i];
+          if (!activeGroup.contains(object)) {
+            objsToRender.push(object);
+          }
+          else {
+            activeGroupObjects.push(object);
+          }
+        }
+        activeGroup._set('_objects', activeGroupObjects);
+      }
+      else {
+        objsToRender = this._objects;
+      }
+      return objsToRender;
+    },
+
+    /**
      * Renders both the top canvas and the secondary container canvas.
      * @param {Boolean} [allOnTop] Whether we want to force all images to be rendered on the top canvas
      * @return {fabric.Canvas} instance
      * @chainable
      */
     renderAll: function () {
-      var canvasToDrawOn = this.contextContainer,
-          activeGroup = this.getActiveGroup();
+      var canvasToDrawOn = this.contextContainer, objsToRender;
 
       if (this.contextTop && this.selection && !this._groupSelector) {
         this.clearContext(this.contextTop);
@@ -869,9 +865,16 @@
         fabric.util.clipContext(this, canvasToDrawOn);
       }
 
+      objsToRender = this._chooseObjectsToRender();
+
+      //apply viewport transform once for all rendering process
+      canvasToDrawOn.setTransform.apply(canvasToDrawOn, this.viewportTransform);
       this._renderBackground(canvasToDrawOn);
-      this._renderObjects(canvasToDrawOn, activeGroup);
-      this._renderActiveGroup(canvasToDrawOn, activeGroup);
+      this._renderObjects(canvasToDrawOn, objsToRender);
+      this.preserveObjectStacking || this._renderObjects(canvasToDrawOn, [this.getActiveGroup()]);
+      if (!this.controlsAboveOverlay && this.interactive) {
+        this.drawControls(canvasToDrawOn);
+      }
 
       if (this.clipTo) {
         canvasToDrawOn.restore();
@@ -891,46 +894,35 @@
     /**
      * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {fabric.Group} activeGroup
+     * @param {Array} objects to render
      */
-    _renderObjects: function(ctx, activeGroup) {
-      var i, length;
-
-      // fast path
-      if (!activeGroup || this.preserveObjectStacking) {
-        for (i = 0, length = this._objects.length; i < length; ++i) {
-          this._draw(ctx, this._objects[i]);
-        }
-      }
-      else {
-        for (i = 0, length = this._objects.length; i < length; ++i) {
-          if (this._objects[i] && !activeGroup.contains(this._objects[i])) {
-            this._draw(ctx, this._objects[i]);
-          }
-        }
+    _renderObjects: function(ctx, objects) {
+      for (var i = 0, length = objects.length; i < length; ++i) {
+        objects[i] && objects[i].render(ctx);
       }
     },
 
     /**
      * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {fabric.Group} activeGroup
+     * @param {string} property 'background' or 'overlay'
      */
-    _renderActiveGroup: function(ctx, activeGroup) {
+    _renderBackgroundOrOverlay: function(ctx, property) {
+      var object = this[property + 'Color'];
+      if (object) {
+        ctx.fillStyle = object.toLive
+          ? object.toLive(ctx)
+          : object;
 
-      // delegate rendering to group selection (if one exists)
-      if (activeGroup) {
-
-        //Store objects in group preserving order, then replace
-        var sortedObjects = [];
-        this.forEachObject(function (object) {
-          if (activeGroup.contains(object)) {
-            sortedObjects.push(object);
-          }
-        });
-        // forEachObject reverses the object, so we reverse again
-        activeGroup._set('_objects', sortedObjects.reverse());
-        this._draw(ctx, activeGroup);
+        ctx.fillRect(
+          object.offsetX || 0,
+          object.offsetY || 0,
+          this.width,
+          this.height);
+      }
+      object = this[property + 'Image'];
+      if (object) {
+        object.render(ctx);
       }
     },
 
@@ -939,20 +931,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderBackground: function(ctx) {
-      if (this.backgroundColor) {
-        ctx.fillStyle = this.backgroundColor.toLive
-          ? this.backgroundColor.toLive(ctx)
-          : this.backgroundColor;
-
-        ctx.fillRect(
-          this.backgroundColor.offsetX || 0,
-          this.backgroundColor.offsetY || 0,
-          this.width,
-          this.height);
-      }
-      if (this.backgroundImage) {
-        this._draw(ctx, this.backgroundImage);
-      }
+      this._renderBackgroundOrOverlay(ctx, 'background');
     },
 
     /**
@@ -960,20 +939,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderOverlay: function(ctx) {
-      if (this.overlayColor) {
-        ctx.fillStyle = this.overlayColor.toLive
-          ? this.overlayColor.toLive(ctx)
-          : this.overlayColor;
-
-        ctx.fillRect(
-          this.overlayColor.offsetX || 0,
-          this.overlayColor.offsetY || 0,
-          this.width,
-          this.height);
-      }
-      if (this.overlayImage) {
-        this._draw(ctx, this.overlayImage);
-      }
+      this._renderBackgroundOrOverlay(ctx, 'overlay');
     },
 
     /**


### PR DESCRIPTION
### Current rendering stack and possible improvements.

First I will describe the current renderAll situation.
We start with a _renderBackground.
renderBackgrond calls _draw(backgroundImage).
_draw function has this scheme: 
    save context
    apply viewportTransform
    check if the object should be rendered and actually render it
    (this means object !== activeGroup ||  this.preserveObjectStacking)
    restore context
    renderObjectControls ( exit if not !this.active or render the controls )
_renderObjects ( rendering of all objects )
    render all the objects in stack, or exclude the one in activeGroup depending on preserveObjectStacking and checking if active group contains them
Every object is drawn with _draw, so again save context, apply viewportTransform, again check if the object is in activeGroup,
restore context, renderControls.
_renderActiveGroup (rendering objects of activeGroup) with the
_draw procedure already described.
_renderOverlay mirrored from  _renderBackgroundImage
_renderControls if controlsAboveOverlay, make a global call for rendering controls.

- What '_draw' does? wax on and wax off the viewport transform for every object, wrong in my opinion. and check if an object should be rendered... But all object should be rendered now or later.

- What 'shouldRenderObject' does? basically obey to preserveObjectStacking that decide if we draw all the objects together or if we render before the normal objects and later the activeGroup.
Because objects in activeGroup are still present on canvas, in the objects array, so we need to be careful to do not draw them twice.

All the checks are about being in the activeGroup, so useless for activeGroup itself, useless for background and overlay images.

Proposed changes in this PR.
background image and overlay image are rendered with their render method.
ViewportTransform get applied once for renderAll, with one save and restore context.

Objects are divided into two groups immediately, and then we render the groups one after the other without additional checks.

Because of this changes take over _draw functionality, the _draw function disappear.

All the controls in the canvas are drawn with canvas.drawcontrols.

What actually changes in the rendering stack? controls are always on top of the object pile, (not above overaly ) regardless if the object is on top.
But consider that we have this bug as of now, and this new situation would solve it.
The bug is that when controls are drawn during the stack, they are present on canvas when the objects after the 'active index' are rendered, so any eventual global composite operataion get influenced by them

So in my opinion moving the control in the top of the stack is a good move, also code reduction is noticiable and we should see **minor** performance improvements.

Example of bug:
![image](https://cloud.githubusercontent.com/assets/1194048/9185974/fca2335a-3fc0-11e5-8e5f-a3e792c93922.png)
