### PR TITLE
Reset viewport transform at the end of render all

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -887,7 +887,7 @@
       }
 
       this.fire('after:render');
-
+      canvasToDrawOn.setTransform.apply(canvasToDrawOn, [1, 0, 0, 1, 0, 0]);
       return this;
     },
 


### PR DESCRIPTION
closes #2558 

At the end of renderAll we were not resetting the viewportTransform to neutral.
That is affecting next cycle of renderAll before the first setTransformMatrix.