### PR TITLE
Pass along the dimensions

### DIFF
--- a/src/mixins/canvas_gestures.mixin.js
+++ b/src/mixins/canvas_gestures.mixin.js
@@ -137,7 +137,7 @@
         dim = target._getNonTransformedDimensions();
 
       this._setObjectScale(new fabric.Point(t.scaleX * s * dim.x, t.scaleY * s * dim.y),
-        t, lockScalingX, lockScalingY, null, target.get('lockScalingFlip'));
+        t, lockScalingX, lockScalingY, null, target.get('lockScalingFlip'), dim);
 
       target.setPositionByOrigin(constraintPosition, t.originX, t.originY);
 


### PR DESCRIPTION
The two _scaleObjectBy's expect the dimensions to be passed along, but the only caller doesn't pass in along. This PR is based on assumption.