### PR TITLE
change default strokewidth to 0  for images

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -65,6 +65,14 @@
     meetOrSlice: 'meet',
 
     /**
+     * Width of a stroke.
+     * For image quality a stroke multiple of 2 gives better results.
+     * @type Number
+     * @default
+     */
+    strokeWidth: 0,
+
+    /**
      * private
      * contains last value of scaleX to detect
      * if the Image got resized after the last Render

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -64,7 +64,7 @@
     'height':                   IMG_HEIGHT, // or does it now?
     'fill':                     'rgb(0,0,0)',
     'stroke':                   null,
-    'strokeWidth':              1,
+    'strokeWidth':              0,
     'strokeDashArray':          null,
     'strokeLineCap':            'butt',
     'strokeLineJoin':           'miter',

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -24,7 +24,7 @@
     'height':                   IMG_HEIGHT, // or does it now?
     'fill':                     'rgb(0,0,0)',
     'stroke':                   null,
-    'strokeWidth':              1,
+    'strokeWidth':              0,
     'strokeDashArray':          null,
     'strokeLineCap':            'butt',
     'strokeLineJoin':           'miter',


### PR DESCRIPTION
As discussed in #2590 this gives better rendering results.

closes #2590