### PR TITLE
Fix multi touch scaling speed

### DIFF
--- a/src/mixins/canvas_gestures.mixin.js
+++ b/src/mixins/canvas_gestures.mixin.js
@@ -136,7 +136,7 @@
       var constraintPosition = target.translateToOriginPoint(target.getCenterPoint(), t.originX, t.originY),
           dim = target._getTransformedDimensions();
 
-      this._setObjectScale(new fabric.Point(dim.x * s, dim.y * s),
+      this._setObjectScale(new fabric.Point(t.scaleX * dim.x * s / target.scaleX, t.scaleY * dim.y * s / target.scaleY),
         t, lockScalingX, lockScalingY, null, target.get('lockScalingFlip'), dim);
 
       target.setPositionByOrigin(constraintPosition, t.originX, t.originY);


### PR DESCRIPTION
we need to use transformed dimensions to include effect of skew. but we need to divide by current scale and use just the initial scale plus the scaling factor of gesture.

Closes #2586
closes #2597