### PR TITLE
Fixcontrols

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1248,18 +1248,14 @@
      * @param {CanvasRenderingContext2D} ctx Context to render controls on
      */
     drawControls: function(ctx) {
-      var activeGroup = this.getActiveGroup(),
-          iVpt = fabric.util.invertTransform(this.viewportTransform);
+      var activeGroup = this.getActiveGroup();
 
-      ctx.save();
-      ctx.transform.apply(ctx, iVpt);
       if (activeGroup) {
         activeGroup._renderControls(ctx);
       }
       else {
         this._drawObjectsControls(ctx);
       }
-      ctx.restore();
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -861,28 +861,26 @@
 
       this.fire('before:render');
 
-      canvasToDrawOn.save();
       if (this.clipTo) {
         fabric.util.clipContext(this, canvasToDrawOn);
       }
+      this._renderBackground(canvasToDrawOn);
 
+      canvasToDrawOn.save();
       objsToRender = this._chooseObjectsToRender();
-
       //apply viewport transform once for all rendering process
       canvasToDrawOn.transform.apply(canvasToDrawOn, this.viewportTransform);
-      this._renderBackground(canvasToDrawOn);
       this._renderObjects(canvasToDrawOn, objsToRender);
       this.preserveObjectStacking || this._renderObjects(canvasToDrawOn, [this.getActiveGroup()]);
+      canvasToDrawOn.restore();
+
       if (!this.controlsAboveOverlay && this.interactive) {
         this.drawControls(canvasToDrawOn);
       }
-
       if (this.clipTo) {
         canvasToDrawOn.restore();
       }
-
       this._renderOverlay(canvasToDrawOn);
-
       if (this.controlsAboveOverlay && this.interactive) {
         this.drawControls(canvasToDrawOn);
       }


### PR DESCRIPTION
Fix mistakes introduced with renderAll changes that were changing the order between viewport transform, background rendering and clipping.

Closes #2629 and #2631