### PR TITLE
Group opacity not delegated

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -209,7 +209,8 @@
      */
     delegatedProperties: {
       fill:             true,
-      opacity:          true,
+      stroke:           true,
+      strokeWidth:      true,
       fontFamily:       true,
       fontWeight:       true,
       fontSize:         true,


### PR DESCRIPTION
I'm not a fan of delegate properties at all.
As mentioned in #2643 setting group opacity overrides all elements opacity.

Opacity is directly rendered in every object multiplying object opacity by group opacity, also overriding it would be wrong because setting half opacity for a group of object with mixed opacity levels would result in a flattened opacity for all.

Also if we delegate "fill" i do not see why we should not delegate "stroke" and "strokeWidth" that are not rendered in group, so if we are setting them we can set just on the objects.

closes #2643