### PR TITLE
Justify text to svg

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -1008,7 +1008,7 @@
         return this.__widthOfSpace[lineIndex];
       }
       var line = this._textLines[lineIndex],
-          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex),
+          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
           widthDiff = this.width - wordsWidth,
           numSpaces = line.length - line.replace(this._reSpacesAndTabs, '').length,
           width = widthDiff / numSpaces;
@@ -1022,14 +1022,14 @@
      * @param {Number} line
      * @param {Number} lineIndex
      */
-    _getWidthOfWords: function (ctx, line, lineIndex) {
+    _getWidthOfWords: function (ctx, line, lineIndex, charOffset) {
       var width = 0;
 
       for (var charIndex = 0; charIndex < line.length; charIndex++) {
         var _char = line[charIndex];
 
         if (!_char.match(/\s/)) {
-          width += this._getWidthOfChar(ctx, _char, lineIndex, charIndex);
+          width += this._getWidthOfChar(ctx, _char, lineIndex, charIndex + charOffset);
         }
       }
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -926,7 +926,8 @@
 
     _setSVGTextLineText: function(i, textSpans, height, textLeftOffset, textTopOffset) {
       var yPos = this.fontSize * (this._fontSizeMult - this._fontSizeFraction)
-        - textTopOffset + height - this.height / 2;
+        - textTopOffset + height - this.height / 2,
+          textLine = this.textAlign === 'justify' ? this._setSVGTextLineWords(i) : fabric.util.string.escapeXml(._textLines[i]);
       textSpans.push(
         '<tspan x="',
           toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
@@ -936,7 +937,7 @@
           // doing this on <tspan> elements since setting opacity
           // on containing <text> one doesn't work in Illustrator
           this._getFillAttributes(this.fill), '>',
-          fabric.util.string.escapeXml(this._textLines[i]),
+          textLine,
         '</tspan>'
       );
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -926,8 +926,12 @@
 
     _setSVGTextLineText: function(i, textSpans, height, textLeftOffset, textTopOffset) {
       var yPos = this.fontSize * (this._fontSizeMult - this._fontSizeFraction)
-        - textTopOffset + height - this.height / 2,
-          textLine = this.textAlign === 'justify' ? this._setSVGTextLineWords(i) : fabric.util.string.escapeXml(._textLines[i]);
+        - textTopOffset + height - this.height / 2;
+      if (this.textAlign === 'justify') {
+        // i call from here to do not intefere with IText
+        this.setSVGTextLineJustifed(i, textSpans, height, textLeftOffset, textTopOffset);
+        return;
+      }
       textSpans.push(
         '<tspan x="',
           toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
@@ -937,9 +941,13 @@
           // doing this on <tspan> elements since setting opacity
           // on containing <text> one doesn't work in Illustrator
           this._getFillAttributes(this.fill), '>',
-          textLine,
+          fabric.util.string.escapeXml(this._textLines[i]),
         '</tspan>'
       );
+    },
+
+    setSVGTextLineJustifed: function(i, textSpans, height, textLeftOffset, textTopOffset) {
+      textSpans.push('justified');
     },
 
     _setSVGTextLineBg: function(textBgRects, i, textLeftOffset, textTopOffset, height) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -479,11 +479,12 @@
 
       // stretch the line
       var words = line.split(/\s+/),
-          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex),
+          charOffset = 0,
+          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
           widthDiff = this.width - wordsWidth,
           numSpaces = words.length - 1,
           spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
-          leftOffset = 0, charOffset = 0, word;
+          leftOffset = 0, word;
 
       for (var i = 0, len = words.length; i < len; i++) {
         while (line[charOffset] === ' ' && charOffset < line.length) {
@@ -491,7 +492,7 @@
         }
         word = words[i];
         this._renderChars(method, ctx, word, left + leftOffset, top, lineIndex, charOffset);
-        leftOffset += ctx.measureText(word).width + spaceWidth;
+        leftOffset += this._getWidthOfWords(ctx, word, lineIndex, charOffset) + spaceWidth;
         charOffset += word.length;
       }
     },
@@ -889,9 +890,9 @@
             (this.fontStyle ? 'font-style="' + this.fontStyle + '" ': ''),
             (this.fontWeight ? 'font-weight="' + this.fontWeight + '" ': ''),
             (this.textDecoration ? 'text-decoration="' + this.textDecoration + '" ': ''),
-            'style="', this.getSvgStyles(), '" >',
+            'style="', this.getSvgStyles(), '" >\n',
             textAndBg.textSpans.join(''),
-          '</text>\n',
+          '\t\t</text>\n',
         '\t</g>\n'
       );
     },
@@ -929,11 +930,11 @@
         - textTopOffset + height - this.height / 2;
       if (this.textAlign === 'justify') {
         // i call from here to do not intefere with IText
-        this.setSVGTextLineJustifed(i, textSpans, height, textLeftOffset, textTopOffset);
+        this._setSVGTextLineJustifed(i, textSpans, height, textLeftOffset, textTopOffset);
         return;
       }
       textSpans.push(
-        '<tspan x="',
+        '\t\t<tspan x="',
           toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
           'y="',
           toFixed(yPos, NUM_FRACTION_DIGITS),
@@ -942,11 +943,21 @@
           // on containing <text> one doesn't work in Illustrator
           this._getFillAttributes(this.fill), '>',
           fabric.util.string.escapeXml(this._textLines[i]),
-        '</tspan>'
+        '</tspan>\n'
       );
     },
 
-    setSVGTextLineJustifed: function(i, textSpans, height, textLeftOffset, textTopOffset) {
+    _setSVGTextLineJustifed: function(i, textSpans, height, textLeftOffset, textTopOffset) {
+      var ctx = fabric.util.createCanvasElement().getContext('2d');
+          this._setTextStyles(ctx);
+          line = this._textLines[i],
+          words = line.split(/\s+/),
+          wordsWidth = this._getWidthOfWords(ctx, line, i),
+          widthDiff = this.width - wordsWidth,
+          numSpaces = words.length - 1,
+          spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
+          word;
+          
       textSpans.push('justified');
     },
 

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -49,7 +49,8 @@
     'transformMatrix':           null  
   };
 
-  var TEXT_SVG = '\t<g transform="translate(10.5 26.72)">\n\t\t<text font-family="Times New Roman" font-size="40" font-weight="normal" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" ><tspan x="-10" y="8.98" fill="rgb(0,0,0)">x</tspan></text>\n\t</g>\n';
+  var TEXT_SVG = '\t<g transform="translate(10.5 26.72)">\n\t\t<text font-family="Times New Roman" font-size="40" font-weight="normal" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" >\n\t\t\t<tspan x="-10" y="8.98" fill="rgb(0,0,0)">x</tspan>\n\t\t</text>\n\t</g>\n';
+  var TEXT_SVG_JUSTIFIED = '\t<g transform="translate(50.5 26.72)">\n\t\t<text font-family="Times New Roman" font-size="40" font-weight="normal" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;" >\n\t\t\t<tspan x="-50" y="8.98" fill="rgb(0,0,0)">x</tspan>\n\t\t\t<tspan x="30" y="8.98" fill="rgb(0,0,0)">y</tspan>\n\t\t</text>\n\t</g>\n';
 
   test('constructor', function() {
     ok(fabric.Text);
@@ -260,6 +261,18 @@
     text.width = CHAR_WIDTH;
 
     equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG.replace('font-family="Times New Roman"', 'font-family="\'Arial Black\', Arial"')));
+  });
+  test('toSVG justified', function() {
+    var text = new fabric.Text('x y');
+
+    function removeTranslate(str) {
+      return str.replace(/translate\(.*?\)/, '');
+    }
+
+    // temp workaround for text objects not obtaining width under node
+    text.width = 100;
+    text.textAlign = 'justify'
+    equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_JUSTIFIED));
   });
 
 })();


### PR DESCRIPTION
Fix to justify text in ITEXT

As of now the iText shares  "_renderTextLine" method with normal text.
In normal text we re using ctx.measureText(word) to measure the width of a word, this is currently not accurate for itext, where styles change word by word.

this fix reuse the function "getWordsWidth" with a character offset to measure the width of single word.

![image](https://cloud.githubusercontent.com/assets/1194048/11680409/5dfe8b1c-9e58-11e5-949d-c2aa6316fb7a.png)


Some other optimizations are possible, a this point textbox _measureText and getWidthOfWords are very similar.

This add some tabs and newlines to svg text export also, and textalign "justify" support for text svg export.