### PR TITLE
Fix scrolling on focus on IText on iOS 8/9 Safari

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -4,12 +4,17 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * Initializes hidden textarea (needed to bring up keyboard in iOS)
    */
   initHiddenTextarea: function() {
+    var text = this.canvas.getActiveObject();
+    // Position in the middle because we don't know where the cursor is
+    var left = text.oCoords.ml.x;
+    var top = text.oCoords.ml.y;
+
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: fixed; bottom: 20px; left: 0px; opacity: 0;'
-                                        + ' width: 0px; height: 0px; z-index: -999;';
-    fabric.document.body.appendChild(this.hiddenTextarea);
+    this.hiddenTextarea.style.cssText = 'position: absolute; left: ' + left + 'px; top: ' + top + 'px;'
+                                        + 'opacity: 0; width: 0; height: 0; z-index: -999;';
+    this.canvas.contextContainer.canvas.parentNode.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -4,17 +4,17 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * Initializes hidden textarea (needed to bring up keyboard in iOS)
    */
   initHiddenTextarea: function() {
-    var text = this.canvas.getActiveObject();
     // Position in the middle because we don't know where the cursor is
-    var left = text.oCoords.ml.x;
-    var top = text.oCoords.ml.y;
+    var rect = this.getBoundingRect();
+    var left = rect.left;
+    var top = rect.top + rect.height / 2;
 
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
     this.hiddenTextarea.style.cssText = 'position: absolute; left: ' + left + 'px; top: ' + top + 'px;'
                                         + 'opacity: 0; width: 0; height: 0; z-index: -999;';
-    this.canvas.contextContainer.canvas.parentNode.appendChild(this.hiddenTextarea);
+    this.canvas.lowerCanvasEl.parentNode.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));


### PR DESCRIPTION
Fix insane random scrolling up & down when trying to edit an IText.
The cause is a bug with iOS 8 & 9 and use of fixed position elements.

Fixes [#1985](https://github.com/kangax/fabric.js/issues/1985).

References for bug:
- https://stackoverflow.com/questions/29001977/safari-in-ios8-is-scrolling-screen-when-fixed-elements-get-focus
- https://meta.discourse.org/t/dealing-with-ios-8-mobile-safari-bugs/24101

Note an [alternative PR #2615](https://github.com/kangax/fabric.js/pull/2615) for this issue.