### PR TITLE
Svg pars

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -219,7 +219,7 @@
                     skewY +
                     ')',
 
-        transforms = '(?:' + transform + '(?:' + commaWsp + transform + ')*' + ')',
+        transforms = '(?:' + transform + '(?:' + commaWsp + '*' + transform + ')*' + ')',
 
         transformList = '^\\s*(?:' + transforms + '?)\\s*$',
 


### PR DESCRIPTION
Specs says that a space or comma between two transform is needed.
Chrome and firefox do not care for this space.
So maybe we should not care as well.

closes #2730