### PR TITLE
Fallback to styleElement.text for IE9

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -910,7 +910,8 @@
 
       // very crude parsing of style contents
       for (var i = 0, len = styles.length; i < len; i++) {
-        var styleContents = styles[i].textContent;
+        // IE9 doesn't support textContent, but provides text instead.
+        var styleContents = styles[i].textContent || styles[i].text;
 
         // remove comments
         styleContents = styleContents.replace(/\/\*[\s\S]*?\*\//g, '');


### PR DESCRIPTION
IE9 doesn't provide a `textContent` property on this object.  This caused errors when trying to import SVG files with `<style>` inside them.