### PR TITLE
pass image/img to callback

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -397,13 +397,13 @@
       if (typeof image === 'string') {
         fabric.util.loadImage(image, function(img) {
           this[property] = new fabric.Image(img, options);
-          callback && callback();
+          callback && callback(img);
         }, this, options && options.crossOrigin);
       }
       else {
         options && image.setOptions(options);
         this[property] = image;
-        callback && callback();
+        callback && callback(image);
       }
 
       return this;


### PR DESCRIPTION
Inspired from a stack overflow question, i was thinking this is a relatively free feature that can come handy to set some image properties after loading it.

we can still refer to this[property] in the callback if we do not like this.

What do you think?