### PR TITLE
Fixing guides in zoom

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -10,7 +10,8 @@ function initAligningGuidelines(canvas) {
       aligningLineMargin = 4,
       aligningLineWidth = 1,
       aligningLineColor = 'rgb(0,255,0)',
-      viewportTransform;
+      viewportTransform,
+      zoom = 1;
 
   function drawVerticalLine(coords) {
     drawLine(
@@ -33,8 +34,8 @@ function initAligningGuidelines(canvas) {
     ctx.lineWidth = aligningLineWidth;
     ctx.strokeStyle = aligningLineColor;
     ctx.beginPath();
-    ctx.moveTo(x1 * viewportTransform[0], y1 * viewportTransform[3]);
-    ctx.lineTo(x2 * viewportTransform[0], y2 * viewportTransform[3]);
+    ctx.moveTo(((x1+viewportTransform[4])*zoom), ((y1+viewportTransform[5])*zoom));
+    ctx.lineTo(((x2+viewportTransform[4])*zoom), ((y2+viewportTransform[5])*zoom));
     ctx.stroke();
     ctx.restore();
   }
@@ -55,6 +56,7 @@ function initAligningGuidelines(canvas) {
 
   canvas.on('mouse:down', function () {
     viewportTransform = canvas.viewportTransform;
+    zoom = canvas.getZoom();
   });
 
   canvas.on('object:moving', function(e) {


### PR DESCRIPTION
We were not calculating the guides updated position for pan and zoom. It's fixed now.