### PR TITLE
Change location of rect in 1x1 case

### DIFF
--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -90,7 +90,7 @@
 
       // optimize 1x1 case (used in spray brush)
       if (this.width === 1 && this.height === 1) {
-        ctx.fillRect(0, 0, 1, 1);
+        ctx.fillRect(-0.5, -0.5, 1, 1);
         return;
       }
 


### PR DESCRIPTION
As can be seen in this jsfiddle, https://jsfiddle.net/asteriskman/kk6v0tu4/ , the optimized 1x1 rect was being placed incorrectly. It must be offset by -0.5 in the x and y direction to line up with other rects that are not subject to the 1x1 optimization.