### PR TITLE
fix(itext): fix bug that IME can not be inputted

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -99,14 +99,14 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   /**
    * Composition start
    */
-  onCompositionStart: function(e) {
+  onCompositionStart: function() {
     this.inCompositionMode = true;
   },
 
   /**
    * Composition end
    */
-  onCompositionEnd: function(e) {
+  onCompositionEnd: function() {
     this.inCompositionMode = false;
   },
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -15,6 +15,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     fabric.util.addListener(this.hiddenTextarea, 'input', this.onInput.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'copy', this.copy.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'paste', this.paste.bind(this));
+    fabric.util.addListener(this.hiddenTextarea, 'compositionstart', this.onCompositionStart.bind(this));
+    fabric.util.addListener(this.hiddenTextarea, 'compositionend', this.onCompositionEnd.bind(this));
 
     if (!this._clickHandlerInitialized && this.canvas) {
       fabric.util.addListener(this.canvas.upperCanvasEl, 'click', this.onClick.bind(this));
@@ -81,7 +83,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @param {Event} e Event object
    */
   onInput: function(e) {
-    if (!this.isEditing) {
+    if (!this.isEditing || this.inCompositionMode) {
       return;
     }
     var offset = this.selectionStart || 0,
@@ -92,6 +94,20 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         charsToInsert = this.hiddenTextarea.value.slice(offset, offset + diff);
     this.insertChars(charsToInsert);
     e.stopPropagation();
+  },
+
+  /**
+   * Composition start
+   */
+  onCompositionStart: function(e) {
+    this.inCompositionMode = true;
+  },
+
+  /**
+   * Composition end
+   */
+  onCompositionEnd: function(e) {
+    this.inCompositionMode = false;
   },
 
   /**


### PR DESCRIPTION
Fix #2473 

Fabric.js does not support IME input, it is looks weird especially in Chinese input. 

The reason is fabric just listen the event `oninput`, and calculate a diff between the last two text, then inserts those new chars. The key is It doesn't have a reducing logic here. 

For example, when you type Chinese text with any IME, the previous result may looks like `xxxnanrenwangxxx`,  but the next you will got `xxx男人王xxx` after entered a return button. Note the length of the chars reduce from 16 to 9, but there is no reducing logic in onInput handler.

So I use the events `compositionstart` and `compositionend` to check if users are using IME and prevent any insertion before they ended IME typing.