### PR TITLE
Do not draw control borders in normal group with active objects

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1075,7 +1075,8 @@
      * @param {Boolean} [noTransform] When true, context is not transformed
      */
     _renderControls: function(ctx, noTransform) {
-      if (!this.active || noTransform) {
+      if (!this.active || noTransform
+          || (this.group && this.group !== this.canvas.getActiveGroup())) {
         return;
       }
 


### PR DESCRIPTION
Currently addWithUpdate set objects to active by default ( probably because it has been created for shift click and active group ).

Since we changed the rendering queque, objects inside group that are marked as active get borders drawn too, that is wrong.