### PR TITLE
Textboxspaces

### DIFF
--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -9,7 +9,7 @@
      * @private
      */
     _setSVGTextLineText: function(lineIndex, textSpans, height, textLeftOffset, textTopOffset, textBgRects) {
-      if (!this.styles[lineIndex]) {
+      if (!this.hasStyleOnLine(lineIndex)) {
         fabric.Text.prototype._setSVGTextLineText.call(this,
           lineIndex, textSpans, height, textLeftOffset, textTopOffset);
       }

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -880,6 +880,16 @@
     },
 
     /**
+     * This function is a TEMPORARY fix before restyling svg export
+     * and tspan generation
+     * @param {Number} lineIndex
+     * @private
+     */
+    hasStyleOnLine: function(lineIndex) {
+      return this.styles[lineIndex];
+    },
+
+    /**
      * @param {Number} lineIndex
      * @param {Number} charIndex
      * @param {Boolean} [returnCloneOrEmpty=false]

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -132,6 +132,23 @@
     },
 
     /**
+     * This function is a TEMPORARY fix before restyling svg export
+     * and tspan generation
+     * @param {Number} lineIndex
+     * @private
+     */
+    hasStyleOnLine: function(lineIndex) {
+      if (this._styleMap) {
+        var map = this._styleMap[lineIndex];
+        if (!map) {
+          return null;
+        }
+        lineIndex = map.line;
+      }
+      return this.styles[lineIndex];
+    },
+    
+    /**
      * @param {Number} lineIndex
      * @param {Number} charIndex
      * @param {Boolean} [returnCloneOrEmpty=false]

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -147,7 +147,7 @@
       }
       return this.styles[lineIndex];
     },
-    
+
     /**
      * @param {Number} lineIndex
      * @param {Number} charIndex


### PR DESCRIPTION
Check properly if the iText or TextBox object has the style set for a particular line.
This is a temporary solution untill we can schedule a full svg export cleaning.

Infact big text chunks with same style are exporte as single character tspans.

closes #2829