### PR TITLE
transform context active group

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -312,8 +312,7 @@
 
       if (shouldTransform) {
         ctx.save();
-        var m = target.group.calcTransformMatrix();
-        ctx.transform.apply(ctx, m);
+        ctx.transform.apply(ctx, target.group.calcTransformMatrix());
       }
       target.render(ctx);
       target._renderControls(ctx);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -304,20 +304,30 @@
      */
     isTargetTransparent: function (target, x, y) {
       var hasBorders = target.hasBorders,
-          transparentCorners = target.transparentCorners;
-
+          transparentCorners = target.transparentCorners,
+          ctx = this.contextCache,
+          shouldTransform = target.group && target.group === this.getActiveGroup();
       target.hasBorders = target.transparentCorners = false;
 
-      target.render(this.contextCache);
-      target._renderControls(this.contextCache);
+      if (shouldTransform) {
+        ctx.save();
+        var m = target.group.calcTransformMatrix();
+        console.log(m);
+        ctx.transform.apply(ctx, m);
+      }
+
+      target.render(ctx);
+      target._renderControls(ctx);
+
 
       target.hasBorders = hasBorders;
       target.transparentCorners = transparentCorners;
 
       var isTransparent = fabric.util.isTransparent(
-        this.contextCache, x, y, this.targetFindTolerance);
+        ctx, x, y, this.targetFindTolerance);
+      shouldTransform && ctx.restore();
 
-      this.clearContext(this.contextCache);
+      this.clearContext(ctx);
 
       return isTransparent;
     },

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -307,18 +307,16 @@
           transparentCorners = target.transparentCorners,
           ctx = this.contextCache,
           shouldTransform = target.group && target.group === this.getActiveGroup();
+
       target.hasBorders = target.transparentCorners = false;
 
       if (shouldTransform) {
         ctx.save();
         var m = target.group.calcTransformMatrix();
-        console.log(m);
         ctx.transform.apply(ctx, m);
       }
-
       target.render(ctx);
       target._renderControls(ctx);
-
 
       target.hasBorders = hasBorders;
       target.transparentCorners = transparentCorners;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -916,7 +916,7 @@
 
       // first check current group (if one exists)
       var activeGroup = this.getActiveGroup();
-      if (activeGroup && !skipGroup && this.containsPoint(e, activeGroup)) {
+      if (!skipGroup && this._checkTarget(e, activeGroup, this.getPointer(e, true))) {
         return activeGroup;
       }
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ testrunner.options.log.tests = false;
 testrunner.options.log.assertions = false;
 
 testrunner.options.coverage = true;
-testrunner.options.maxBlockDuration = 240000;
+testrunner.options.maxBlockDuration = 120000;
 
 testrunner.run({
     deps: "./test/fixtures/test_script.js",

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ testrunner.options.log.tests = false;
 testrunner.options.log.assertions = false;
 
 testrunner.options.coverage = true;
-testrunner.options.maxBlockDuration = 120000;
+testrunner.options.maxBlockDuration = 240000;
 
 testrunner.run({
     deps: "./test/fixtures/test_script.js",

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -216,6 +216,12 @@
 
   test('findTarget', function() {
     ok(typeof canvas.findTarget == 'function');
+    var rect = makeRect({ left: 0, top: 0 });
+    canvas.add(rect);
+    var target canvas.findTarget({
+      pointerX: 5, pointerY: 5
+    });
+    equal(rect, target, 'Should return the rect')
   });
 
   test('toDataURL', function() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -241,7 +241,7 @@
       clientX: 2, clientY: 1
     }, true);
     equal(target, triangle, 'Should return the triangle by bounding box');
-    canvas.perPixelTargetFind = true;
+    //canvas.perPixelTargetFind = true;
     target = canvas.findTarget({
       clientX: 2, clientY: 1
     }, true);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -238,24 +238,24 @@
     }
   });
 
-  asyncTest('getPointer', function() {
-    ok(typeof canvas.getPointer == 'function');
+//  asyncTest('getPointer', function() {
+//    ok(typeof canvas.getPointer == 'function');
+//
+//    fabric.util.addListener(upperCanvasEl, 'click', function(e) {
+//       canvas.calcOffset();
+//       var pointer = canvas.getPointer(e);
+//       equal(pointer.x, 101, 'pointer.x should be correct');
+//       equal(pointer.y, 102, 'pointer.y should be correct');
+//
+//       start();
+//   });
 
-    fabric.util.addListener(upperCanvasEl, 'click', function(e) {
-       canvas.calcOffset();
-       var pointer = canvas.getPointer(e);
-       equal(pointer.x, 101, 'pointer.x should be correct');
-       equal(pointer.y, 102, 'pointer.y should be correct');
-
-       start();
-   });
-
-     setTimeout(function() {
-       simulateEvent(upperCanvasEl, 'click', {
-         pointerX: 101, pointerY: 102
-       });
-     }, 100);
- });
+//     setTimeout(function() {
+//       simulateEvent(upperCanvasEl, 'click', {
+//         pointerX: 101, pointerY: 102
+//       });
+//     }, 100);
+// });
 
   test('getCenter', function() {
     ok(typeof canvas.getCenter == 'function');

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -62,7 +62,7 @@
 
   function makeTriangle(options) {
     var defaultOptions = { width: 10, height: 10 };
-    return new fabric.Traingle(fabric.util.object.extend(defaultOptions, options || { }));
+    return new fabric.Triangle(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
   QUnit.module('fabric.Canvas', {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -246,10 +246,10 @@
       clientX: 2, clientY: 1
     }, true);
     equal(target, null, 'Should return null because of transparency checks');
-    target = canvas.findTarget({
-      clientX: 5, clientY: 5
-    }, true);
-    equal(target, triangle, 'Should return the triangle now');
+    //target = canvas.findTarget({
+    //  clientX: 5, clientY: 5
+    //}, true);
+    //equal(target, triangle, 'Should return the triangle now');
   });
 
   test('toDataURL', function() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -60,6 +60,11 @@
     return new fabric.Rect(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
+  function makeTriangle(options) {
+    var defaultOptions = { width: 10, height: 10 };
+    return new fabric.Traingle(fabric.util.object.extend(defaultOptions, options || { }));
+  }
+
   QUnit.module('fabric.Canvas', {
     setup: function() {
       upperCanvasEl.style.display = '';
@@ -216,12 +221,35 @@
 
   test('findTarget', function() {
     ok(typeof canvas.findTarget == 'function');
-    var rect = makeRect({ left: 0, top: 0 });
+    var rect = makeRect({ left: 0, top: 0 }), target;
     canvas.add(rect);
-    var target = canvas.findTarget({
+    target = canvas.findTarget({
       clientX: 5, clientY: 5
     }, true);
-    equal(rect, target, 'Should return the rect')
+    equal(target, rect, 'Should return the rect');
+    target = canvas.findTarget({
+      clientX: 30, clientY: 30
+    }, true);
+    equal(target, null, 'Should not find target');
+  });
+
+  test('findTarget with perPixelTargetFind', function() {
+    ok(typeof canvas.findTarget == 'function');
+    var triangle = makeTriangle({ left: 0, top: 0 }), target;
+    canvas.add(triangle);
+    target = canvas.findTarget({
+      clientX: 2, clientY: 1
+    }, true);
+    equal(target, triangle, 'Should return the triangle by bounding box');
+    canvas.perPixelTargetFind = true;
+    target = canvas.findTarget({
+      clientX: 2, clientY: 1
+    }, true);
+    equal(target, null, 'Should return null because of transparency checks');
+    target = canvas.findTarget({
+      clientX: 5, clientY: 5
+    }, true);
+    equal(target, triangle, 'Should return the triangle now');
   });
 
   test('toDataURL', function() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -241,7 +241,7 @@
       clientX: 2, clientY: 1
     }, true);
     equal(target, triangle, 'Should return the triangle by bounding box');
-    //canvas.perPixelTargetFind = true;
+    canvas.perPixelTargetFind = true;
     target = canvas.findTarget({
       clientX: 2, clientY: 1
     }, true);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -218,7 +218,7 @@
     ok(typeof canvas.findTarget == 'function');
     var rect = makeRect({ left: 0, top: 0 });
     canvas.add(rect);
-    var target canvas.findTarget({
+    var target = canvas.findTarget({
       pointerX: 5, pointerY: 5
     });
     equal(rect, target, 'Should return the rect')

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -219,8 +219,8 @@
     var rect = makeRect({ left: 0, top: 0 });
     canvas.add(rect);
     var target = canvas.findTarget({
-      pointerX: 5, pointerY: 5
-    });
+      clientX: 5, clientY: 5
+    }, true);
     equal(rect, target, 'Should return the rect')
   });
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -232,26 +232,26 @@
     }
   });
 
-  // asyncTest('getPointer', function() {
-  //   ok(typeof canvas.getPointer == 'function');
+  asyncTest('getPointer', function() {
+    ok(typeof canvas.getPointer == 'function');
 
-  //   window.scroll(0, 0);
+    window.scroll(0, 0);
 
-  //   fabric.util.addListener(upperCanvasEl, 'click', function(e) {
-  //     canvas.calcOffset();
-  //     var pointer = canvas.getPointer(e);
-  //     equal(pointer.x, 101, 'pointer.x should be correct');
-  //     equal(pointer.y, 102, 'pointer.y should be correct');
+    fabric.util.addListener(upperCanvasEl, 'click', function(e) {
+       canvas.calcOffset();
+       var pointer = canvas.getPointer(e);
+       equal(pointer.x, 101, 'pointer.x should be correct');
+       equal(pointer.y, 102, 'pointer.y should be correct');
 
-  //     start();
-  //   });
+       start();
+   });
 
-  //   setTimeout(function() {
-  //     simulateEvent(upperCanvasEl, 'click', {
-  //       pointerX: 101, pointerY: 102
-  //     });
-  //   }, 100);
-  // });
+     setTimeout(function() {
+       simulateEvent(upperCanvasEl, 'click', {
+         pointerX: 101, pointerY: 102
+       });
+     }, 100);
+ });
 
   test('getCenter', function() {
     ok(typeof canvas.getCenter == 'function');

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -258,7 +258,7 @@
 
   test('findTarget on activegroup', function() {
     var rect1 = makeRect({ left: 0, top: 0 }), target;
-    var rect2 = makeRect({ left: 20, top: 0 }), target;
+    var rect2 = makeRect({ left: 20, top: 0 });
     canvas.add(rect1);
     canvas.add(rect2);
     var group = new fabric.Group([ rect1, rect2 ]);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -235,8 +235,6 @@
   asyncTest('getPointer', function() {
     ok(typeof canvas.getPointer == 'function');
 
-    window.scroll(0, 0);
-
     fabric.util.addListener(upperCanvasEl, 'click', function(e) {
        canvas.calcOffset();
        var pointer = canvas.getPointer(e);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -256,6 +256,22 @@
     canvas.remove(triangle);
   });
 
+  test('findTarget on activegroup', function() {
+    var rect1 = makeRect({ left: 0, top: 0 }), target;
+    var rect2 = makeRect({ left: 20, top: 0 }), target;
+    canvas.add(rect1);
+    canvas.add(rect2);
+    var group = new fabric.Group([ rect1, rect2 ]);
+    canvas.add(group);
+    canvas.setActiveGroup(group);
+    target = canvas.findTarget({
+      clientX: 5, clientY: 5
+    }, true);
+    equal(target, group, 'Should return the activegroup');
+    //TODO: make it work with perPixelTargetFind
+  });
+
+
   test('toDataURL', function() {
     ok(typeof canvas.toDataURL == 'function');
     if (!fabric.Canvas.supports('toDataURL')) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -242,11 +242,12 @@
       clientX: 2, clientY: 1
     }, true);
     equal(target, triangle, 'Should return the triangle by bounding box');
-    canvas.perPixelTargetFind = true;
-    target = canvas.findTarget({
-      clientX: 2, clientY: 1
-    }, true);
-    equal(target, null, 'Should return null because of transparency checks');
+    //TODO find out why this stops the tests
+    //canvas.perPixelTargetFind = true;
+    //target = canvas.findTarget({
+    //  clientX: 2, clientY: 1
+    //}, true);
+    //equal(target, null, 'Should return null because of transparency checks');
     target = canvas.findTarget({
       clientX: 5, clientY: 5
     }, true);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -231,6 +231,7 @@
       clientX: 30, clientY: 30
     }, true);
     equal(target, null, 'Should not find target');
+    canvas.remove(rect);
   });
 
   test('findTarget with perPixelTargetFind', function() {
@@ -246,10 +247,12 @@
       clientX: 2, clientY: 1
     }, true);
     equal(target, null, 'Should return null because of transparency checks');
-    //target = canvas.findTarget({
-    //  clientX: 5, clientY: 5
-    //}, true);
-    //equal(target, triangle, 'Should return the triangle now');
+    target = canvas.findTarget({
+      clientX: 5, clientY: 5
+    }, true);
+    equal(target, triangle, 'Should return the triangle now');
+    canvas.perPixelTargetFind = false;
+    canvas.remove(triangle);
   });
 
   test('toDataURL', function() {


### PR DESCRIPTION
Back from when the issues were only 3 digits long.

If we transform canvas with the activeGroup matrix, we can properly detect the transparency of the pixels.

closes #532

@Kienz 