### PR TITLE
Do not clear the contextTop if we are in drawingMode.   closes #2723

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -855,7 +855,7 @@
     renderAll: function () {
       var canvasToDrawOn = this.contextContainer, objsToRender;
 
-      if (this.contextTop && this.selection && !this._groupSelector &&!this.isDrawingMode) {
+      if (this.contextTop && this.selection && !this._groupSelector && !this.isDrawingMode) {
         this.clearContext(this.contextTop);
       }
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -855,7 +855,7 @@
     renderAll: function () {
       var canvasToDrawOn = this.contextContainer, objsToRender;
 
-      if (this.contextTop && this.selection && !this._groupSelector) {
+      if (this.contextTop && this.selection && !this._groupSelector &&!this.isDrawingMode) {
         this.clearContext(this.contextTop);
       }
 


### PR DESCRIPTION
Do not clear the contextTop if we are in drawingMode.

This allow to draw over a rendering canvas. ( animation in background , animated sprite )

closes #2723