### PR TITLE
Allow hoverCursor to appear on non selectable objects.

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -457,7 +457,7 @@
 
         if (target !== this.getActiveGroup() && target !== this.getActiveObject()) {
           this.deactivateAll();
-          this.setActiveObject(target, e);
+          target.selectable && this.setActiveObject(target, e);
         }
       }
       // we must renderAll so that active image is placed on the top canvas
@@ -693,12 +693,13 @@
      * @param {Object} target Object that the mouse is hovering, if so.
      */
     _setCursorFromEvent: function (e, target) {
-      var hoverCursor = target.hoverCursor || this.hoverCursor;
       if (!target) {
         this.setCursor(this.defaultCursor);
         return false;
       }
-      else if (!target.selectable) {
+
+      var hoverCursor = target.hoverCursor || this.hoverCursor;
+      if (!target.selectable) {
         //let's skip _findTargetCorner if object is not selectable
         this.setCursor(hoverCursor);
       }

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -631,7 +631,7 @@
       else {
         if (actionPerformed = this._translateObject(x, y)) {
           this._fire('moving', target, e);
-          this.setCursor(this.moveCursor);
+          this.setCursor(target.moveCursor || this.moveCursor);
         }
       }
       transform.actionPerformed = actionPerformed;

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -629,7 +629,8 @@
         (actionPerformed = this._skewObject(x, y, 'y')) && this._fire('skewing', target, e);
       }
       else {
-        if (actionPerformed = this._translateObject(x, y)) {
+        actionPerformed = this._translateObject(x, y);
+        if (actionPerformed) {
           this._fire('moving', target, e);
           this.setCursor(target.moveCursor || this.moveCursor);
         }

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -572,18 +572,10 @@
         this.renderTop();
       }
       else if (!this._currentTransform) {
-
         target = this.findTarget(e);
-
-        if (!target || target && !target.selectable) {
-          this.setCursor(this.defaultCursor);
-        }
-        else {
-          this._setCursorFromEvent(e, target);
-        }
+        this._setCursorFromEvent(e, target);
       }
       else {
-
         this._transformObject(e);
       }
 
@@ -698,9 +690,14 @@
      * @param {Object} target Object that the mouse is hovering, if so.
      */
     _setCursorFromEvent: function (e, target) {
-      if (!target || !target.selectable) {
+      var hoverCursor = target.hoverCursor || this.hoverCursor;
+      if (!target) {
         this.setCursor(this.defaultCursor);
         return false;
+      }
+      else if (!target.selectable) {
+        //let's skip _findTargetCorner if object is not selectable
+        this.setCursor(hoverCursor);
       }
       else {
         var activeGroup = this.getActiveGroup(),
@@ -710,12 +707,14 @@
                       && target._findTargetCorner(this.getPointer(e, true));
 
         if (!corner) {
-          this.setCursor(target.hoverCursor || this.hoverCursor);
+          this.setCursor(hoverCursor);
         }
         else {
           this._setCornerCursor(corner, target, e);
         }
       }
+      //actually unclear why it should return something
+      //is never evaluated
       return true;
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -629,8 +629,10 @@
         (actionPerformed = this._skewObject(x, y, 'y')) && this._fire('skewing', target, e);
       }
       else {
-        (actionPerformed = this._translateObject(x, y)) && this._fire('moving', target, e);
-        this.setCursor(this.moveCursor);
+        if (actionPerformed = this._translateObject(x, y)) {
+          this._fire('moving', target, e);
+          this.setCursor(this.moveCursor);
+        }
       }
       transform.actionPerformed = actionPerformed;
     },

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -421,6 +421,13 @@
     hoverCursor:              null,
 
     /**
+     * Default cursor value used when moving this object on canvas
+     * @type String
+     * @default
+     */
+    moveCursor:               null,
+
+    /**
      * Padding between object and its controlling borders (in pixels)
      * @type Number
      * @default


### PR DESCRIPTION
Removed some duplicate checks also.
Also moveCursor does not appear if the object is not moveable.
Added object.moveCursor to specify a cursor for moving an object.

Closes #1392
Closes #2360