### PR TITLE
Control customization part 1 - Set dashed line to controls and borders

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -201,14 +201,12 @@
       }
 
       var wh = this._calculateCurrentDimensions(),
-          strokeWidth = 1 / this.borderScaleFactor,
           width = wh.x + strokeWidth,
           height = wh.y + strokeWidth;
 
       ctx.save();
       ctx.strokeStyle = this.borderColor;
       this._setLineDash(ctx, this.borderDashArray, null);
-      ctx.lineWidth = strokeWidth;
 
       ctx.strokeRect(
         -width / 2,
@@ -249,14 +247,12 @@
       var p = this._getNonTransformedDimensions(),
           matrix = fabric.util.customTransformMatrix(options.scaleX, options.scaleY, options.skewX),
           wh = fabric.util.transformPoint(p, matrix),
-          strokeWidth = 1 / this.borderScaleFactor,
           width = wh.x + strokeWidth + 2 * this.padding,
           height = wh.y + strokeWidth + 2 * this.padding;
 
       ctx.save();
       this._setLineDash(ctx, this.borderDashArray, null);
       ctx.strokeStyle = this.borderColor;
-      ctx.lineWidth = strokeWidth;
 
       ctx.strokeRect(
         -width / 2,
@@ -294,6 +290,7 @@
 
       ctx.lineWidth = 1;
       ctx.strokeStyle = ctx.fillStyle = this.cornerColor;
+      this._setLineDash(ctx, this.controlDashArray, null);
 
       // top-left
       this._drawControl('tl', ctx, methodName,

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -201,6 +201,7 @@
       }
 
       var wh = this._calculateCurrentDimensions(),
+          strokeWidth = 1 / this.bordeScaleFactor,
           width = wh.x + strokeWidth,
           height = wh.y + strokeWidth;
 
@@ -247,6 +248,7 @@
       var p = this._getNonTransformedDimensions(),
           matrix = fabric.util.customTransformMatrix(options.scaleX, options.scaleY, options.skewX),
           wh = fabric.util.transformPoint(p, matrix),
+          strokeWidth = 1 / this.bordeScaleFactor,
           width = wh.x + strokeWidth + 2 * this.padding,
           height = wh.y + strokeWidth + 2 * this.padding;
 

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -201,7 +201,7 @@
       }
 
       var wh = this._calculateCurrentDimensions(),
-          strokeWidth = 1 / this.bordeScaleFactor,
+          strokeWidth = 1 / this.borderScaleFactor,
           width = wh.x + strokeWidth,
           height = wh.y + strokeWidth;
 
@@ -248,7 +248,7 @@
       var p = this._getNonTransformedDimensions(),
           matrix = fabric.util.customTransformMatrix(options.scaleX, options.scaleY, options.skewX),
           wh = fabric.util.transformPoint(p, matrix),
-          strokeWidth = 1 / this.bordeScaleFactor,
+          strokeWidth = 1 / this.borderScaleFactor,
           width = wh.x + strokeWidth + 2 * this.padding,
           height = wh.y + strokeWidth + 2 * this.padding;
 

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -206,8 +206,8 @@
           height = wh.y + strokeWidth;
 
       ctx.save();
-      ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
       ctx.strokeStyle = this.borderColor;
+      this._setLineDash(ctx, this.borderDashArray, null);
       ctx.lineWidth = strokeWidth;
 
       ctx.strokeRect(
@@ -254,8 +254,7 @@
           height = wh.y + strokeWidth + 2 * this.padding;
 
       ctx.save();
-
-      ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
+      this._setLineDash(ctx, this.borderDashArray, null);
       ctx.strokeStyle = this.borderColor;
       ctx.lineWidth = strokeWidth;
 
@@ -294,8 +293,6 @@
       ctx.save();
 
       ctx.lineWidth = 1;
-
-      ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
       ctx.strokeStyle = ctx.fillStyle = this.cornerColor;
 
       // top-left

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -292,7 +292,7 @@
 
       ctx.lineWidth = 1;
       ctx.strokeStyle = ctx.fillStyle = this.cornerColor;
-      this._setLineDash(ctx, this.controlDashArray, null);
+      this._setLineDash(ctx, this.cornerDashArray, null);
 
       // top-left
       this._drawControl('tl', ctx, methodName,

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1126,6 +1126,7 @@
       options = fabric.util.qrDecompose(matrix);
       ctx.save();
       ctx.translate(options.translateX, options.translateY);
+      ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
       if (this.group && this.group === this.canvas.getActiveGroup()) {
         ctx.rotate(degreesToRadians(options.angle));
         this.drawBordersInGroup(ctx, options);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -455,6 +455,13 @@
      */
     cornerColor:              'rgba(102,153,255,0.5)',
 
+     /**
+      * Array specifying dash pattern of an object's control (hasBorder must be true)
+      * @since 1.6.2
+      * @type Array
+      */
+     controlDashArray:          null,
+
     /**
      * When true, this object will use center point as the origin of transformation
      * when being scaled via the controls.
@@ -1124,9 +1131,12 @@
           options;
       matrix = fabric.util.multiplyTransformMatrices(vpt, matrix);
       options = fabric.util.qrDecompose(matrix);
+
       ctx.save();
       ctx.translate(options.translateX, options.translateY);
+      ctx.lineWidth = 1 / this.borderScaleFactor;
       ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
+
       if (this.group && this.group === this.canvas.getActiveGroup()) {
         ctx.rotate(degreesToRadians(options.angle));
         this.drawBordersInGroup(ctx, options);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -404,7 +404,7 @@
      * @type Number
      * @default
      */
-    cornerSize:               12,
+    cornerSize:               13,
 
     /**
      * When true, object's controlling corners are rendered as transparent inside (i.e. stroke instead of fill)

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -447,7 +447,7 @@
      * @type Array
      */
     borderDashArray:          null,
- 
+
     /**
      * Color of controlling corners of an object (when it's active)
      * @type String

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -441,12 +441,12 @@
      */
     borderColor:              'rgba(102,153,255,0.75)',
 
-     /**
-      * Array specifying dash pattern of an object's borders (hasBorder must be true)
-      * @since 1.6.2
-      * @type Array
-      */
-     borderDashArray:          null,
+    /**
+     * Array specifying dash pattern of an object's borders (hasBorder must be true)
+     * @since 1.6.2
+     * @type Array
+     */
+    borderDashArray:          null,
  
     /**
      * Color of controlling corners of an object (when it's active)
@@ -455,12 +455,12 @@
      */
     cornerColor:              'rgba(102,153,255,0.5)',
 
-     /**
-      * Array specifying dash pattern of an object's control (hasBorder must be true)
-      * @since 1.6.2
-      * @type Array
-      */
-     cornerDashArray:          null,
+    /**
+     * Array specifying dash pattern of an object's control (hasBorder must be true)
+     * @since 1.6.2
+     * @type Array
+     */
+    cornerDashArray:          null,
 
     /**
      * When true, this object will use center point as the origin of transformation

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -460,7 +460,7 @@
       * @since 1.6.2
       * @type Array
       */
-     controlDashArray:          null,
+     cornerDashArray:          null,
 
     /**
      * When true, this object will use center point as the origin of transformation

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1079,6 +1079,29 @@
     },
 
     /**
+     * @private
+     * Sets line dash
+     * @param {CanvasRenderingContext2D} ctx Context to set the dash line on
+     * @param {Array} dashArray array representing dashes
+     * @param {Function} alternative function to call if browaser does not support lineDash
+     */
+    _setLineDash: function(ctx, dashArray, alternative) {
+      if (!dashArray) {
+        return;
+      }
+      // Spec requires the concatenation of two copies the dash list when the number of elements is odd
+      if (1 & dashArray.length) {
+        dashArray.push.apply(dashArray, dashArray);
+      }
+      if (supportsLineDash) {
+        ctx.setLineDash(dashArray);
+      }
+      else {
+        alternative && alternative(ctx);
+      }
+    },
+
+    /**
      * Renders controls and borders for the object
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Boolean} [noTransform] When true, context is not transformed
@@ -1185,18 +1208,7 @@
 
       ctx.save();
 
-      if (this.strokeDashArray) {
-        // Spec requires the concatenation of two copies the dash list when the number of elements is odd
-        if (1 & this.strokeDashArray.length) {
-          this.strokeDashArray.push.apply(this.strokeDashArray, this.strokeDashArray);
-        }
-        if (supportsLineDash) {
-          ctx.setLineDash(this.strokeDashArray);
-        }
-        else {
-          this._renderDashedStroke && this._renderDashedStroke(ctx);
-        }
-      }
+      this._setLineDash(ctx, this.strokeDashArray, this._renderDashedStroke);
       if (this.stroke.gradientTransform) {
         var g = this.stroke.gradientTransform;
         ctx.transform.apply(ctx, g);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -441,6 +441,13 @@
      */
     borderColor:              'rgba(102,153,255,0.75)',
 
+     /**
+      * Array specifying dash pattern of an object's borders (hasBorder must be true)
+      * @since 1.6.2
+      * @type Array
+      */
+     borderDashArray:          null,
+ 
     /**
      * Color of controlling corners of an object (when it's active)
      * @type String

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -755,6 +755,17 @@ test('toDataURL & reference to canvas', function() {
     equal(object.get('left'), 112.45, 'non boolean properties should not be affected');
   });
 
+  test('_setLineDash', function() {
+    var object = new fabric.Object({ left: 100, top: 124, width: 210, height: 66 });
+    ok(typeof object._setLineDash == 'function');
+
+    canvas.add(object);
+    object.strokeDashArray = [3, 2, 1];
+    equal(object.strokeDashArray.length, 3, 'strokeDash array is odd');
+    canvas.renderAll();
+    equal(object.strokeDashArray.length, 6, 'strokeDash array now is even');
+  });
+
   test('straighten', function() {
     var object = new fabric.Object({ left: 100, top: 124, width: 210, height: 66 });
     ok(typeof object.straighten == 'function');

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -756,8 +756,8 @@ test('toDataURL & reference to canvas', function() {
   });
 
   test('_setLineDash', function() {
-    var object = new fabric.Object({ left: 100, top: 124, width: 210, height: 66 });
-    ok(typeof object._setLineDash == 'function');
+    var object = new fabric.Rect({ left: 100, top: 124, width: 210, height: 66 });
+    ok(typeof object._setLineDash === 'function');
 
     canvas.add(object);
     object.strokeDashArray = [3, 2, 1];

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -756,7 +756,7 @@ test('toDataURL & reference to canvas', function() {
   });
 
   test('_setLineDash', function() {
-    var object = new fabric.Rect({ left: 100, top: 124, width: 210, height: 66 });
+    var object = new fabric.Rect({ left: 100, top: 124, width: 210, height: 66, stroke: 'black', strokeWidth: 2});
     ok(typeof object._setLineDash === 'function');
 
     canvas.add(object);


### PR DESCRIPTION
Give controls and borders chance to be dashed trought

added:
- cornerDashArray
- borderDashArray
- borderScaleFactor influences both border and controls now
- changed default corner size to 13:
(a default size of 12 is always out of focus when borders are on focus and viceversa, at least now they are same. difference is not noticeable because the 1st and 12th pixel where always across 2 different pixels)