### PR TITLE
Control customization part 4 - draw selection background

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -189,7 +189,6 @@
 
     /**
      * Draws a colored layer behind the object, inside its selection borders.
-     * Requires public properties: width, height
      * Requires public options: padding, backgroundSelectionColor
      * this function is called when the context is transformed
      * @param {CanvasRenderingContext2D} ctx Context to draw on
@@ -200,11 +199,13 @@
       if (!this.selectionBackgroundColor || !this.active || this.group) {
         return this;
       }
-      var pad = this.padding, width = this.width + 2 * pad,
-          height = this.height + 2 * pad, top = this.top + pad,
-          left = this.left + pad;
-          
-      ctx.fillRect(-left, -top, width, height);
+      ctx.save();
+      var center = this.getCenterPoint(), wh = this._calculateCurrentDimensions();
+      ctx.translate(center.x, center.y);
+      ctx.rotate(degreesToRadians(this.angle));
+      ctx.fillStyle = this.selectionBackgroundColor;
+      ctx.fillRect(-wh.x/2, -wh.y/2, wh.x, wh.y);
+      ctx.restore();
       return this;
     },
 

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -358,15 +358,15 @@
         return;
       }
       var size = this.cornerSize, stroke = !this.transparentCorners && this.cornerStrokeColor;
-      switch(this.cornerStyle) {
+      switch (this.cornerStyle) {
         case 'circle':
           ctx.beginPath();
           ctx.arc(left + size/2, top + size/2, size/2, 0, 2 * Math.PI, false);
           ctx[methodName]();
-          if(stroke) {
+          if (stroke) {
             ctx.stroke();
           }
-        break;
+          break;
         default:
           isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
           ctx[methodName + 'Rect'](left, top, size, size);

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -188,6 +188,27 @@
     },
 
     /**
+     * Draws a colored layer behind the object, inside its selection borders.
+     * Requires public properties: width, height
+     * Requires public options: padding, backgroundSelectionColor
+     * this function is called when the context is transformed
+     * @param {CanvasRenderingContext2D} ctx Context to draw on
+     * @return {fabric.Object} thisArg
+     * @chainable
+     */
+    drawSelectionBackground: function(ctx) {
+      if (!this.backgroundSelectionColor || !this.active || this.group) {
+        return this;
+      }
+      var pad = this.padding, width = this.width + 2 * pad,
+          height = this.height + 2 * pad, top = this.top + pad,
+          left = this.left + pad;
+          
+      ctx.fillRect(-left, -top, width, height);
+      return this;
+    },
+
+    /**
      * Draws borders of an object's bounding box.
      * Requires public properties: width, height
      * Requires public options: padding, borderColor

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -367,7 +367,6 @@
             ctx.stroke();
           }
         break;
-        case 'rect':
         default:
           isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
           ctx[methodName + 'Rect'](left, top, size, size);

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -286,7 +286,7 @@
           scaleOffset = this.cornerSize,
           left = -(width + scaleOffset) / 2,
           top = -(height + scaleOffset) / 2,
-          methodName = this.transparentCorners ? 'strokeRect' : 'fillRect';
+          methodName = this.transparentCorners ? 'stroke' : 'fill';
 
       ctx.save();
       ctx.strokeStyle = ctx.fillStyle = this.cornerColor;
@@ -357,11 +357,23 @@
       if (!this.isControlVisible(control)) {
         return;
       }
-      var size = this.cornerSize;
-      isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
-      ctx[methodName](left, top, size, size);
-      if (!this.transparentCorners && this.cornerStrokeColor) {
-        ctx.strokeRect(left, top, size, size);
+      var size = this.cornerSize, stroke = !this.transparentCorners && this.cornerStrokeColor;
+      switch(this.cornerStyle) {
+        case 'circle':
+          ctx.beginPath();
+          ctx.arc(left + size/2, top + size/2, size/2, 0, 2 * Math.PI, false);
+          ctx[methodName]();
+          if(stroke) {
+            ctx.stroke();
+          }
+        break;
+        case 'rect':
+        default:
+          isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
+          ctx[methodName + 'Rect'](left, top, size, size);
+          if (stroke) {
+            ctx.strokeRect(left, top, size, size);
+          }
       }
     },
 

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -189,7 +189,7 @@
 
     /**
      * Draws a colored layer behind the object, inside its selection borders.
-     * Requires public options: padding, backgroundSelectionColor
+     * Requires public options: padding, selectionBackgroundColor
      * this function is called when the context is transformed
      * @param {CanvasRenderingContext2D} ctx Context to draw on
      * @return {fabric.Object} thisArg

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -197,7 +197,7 @@
      * @chainable
      */
     drawSelectionBackground: function(ctx) {
-      if (!this.backgroundSelectionColor || !this.active || this.group) {
+      if (!this.selectionBackgroundColor || !this.active || this.group) {
         return this;
       }
       var pad = this.padding, width = this.width + 2 * pad,

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -528,6 +528,14 @@
     backgroundColor:          '',
 
     /**
+     * Selection Background color of an object. colored layer behind the object when it is active.
+     * does not mix good with globalCompositeOperation methods.
+     * @type String
+     * @default
+     */
+    selectionBackgroundColor:          '',
+
+    /**
      * When defined, an object is rendered via stroke and this property specifies its color
      * @type String
      * @default
@@ -1062,6 +1070,7 @@
       if (!noTransform) {
         this.transform(ctx);
       }
+      this.drawSelectionBackground(ctx);
       this._setStrokeStyles(ctx);
       this._setFillStyles(ctx);
       if (this.transformMatrix) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1067,10 +1067,10 @@
 
       //setup fill rule for current object
       this._setupCompositeOperation(ctx);
+      this.drawSelectionBackground(ctx);
       if (!noTransform) {
         this.transform(ctx);
       }
-      this.drawSelectionBackground(ctx);
       this._setStrokeStyles(ctx);
       this._setFillStyles(ctx);
       if (this.transformMatrix) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -468,7 +468,7 @@
      * @since 1.6.2
      * @type String
      */
-    cornerStyle:          'rect,
+    cornerStyle:          'rect',
 
     /**
      * Array specifying dash pattern of an object's control (hasBorder must be true)

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -464,6 +464,13 @@
     cornerStrokeColor:        null,
 
     /**
+     * Specify style of control, 'rect' or 'circle'
+     * @since 1.6.2
+     * @type String
+     */
+    cornerStyle:          'rect,
+
+    /**
      * Array specifying dash pattern of an object's control (hasBorder must be true)
      * @since 1.6.2
      * @type Array

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -816,6 +816,7 @@
       if (this._shouldClearCache()) {
         this._initDimensions(ctx);
       }
+      this.drawSelectionBackground(ctx);
       if (!noTransform) {
         this.transform(ctx);
       }


### PR DESCRIPTION
Add an extra layer between behind object when selected.
Helps visibility when using objects over pictures. Not easily addable by the developers without overriding the render method.

Added a new object option: selectionBackgroundColor default to null

![image](https://cloud.githubusercontent.com/assets/1194048/15096323/49efd40c-14f3-11e6-82a0-23d9c3cddf6d.png)

![image](https://cloud.githubusercontent.com/assets/1194048/15096325/5493a654-14f3-11e6-8f19-661833b7f7a9.png)