### PR TITLE
Use scaled canvas dimensions

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1333,7 +1333,7 @@
       };
 
       this.set('active', false);
-      this.setPositionByOrigin(new fabric.Point(el.width / 2, el.height / 2), 'center', 'center');
+      this.setPositionByOrigin(new fabric.Point(canvas.getWidth() / 2, canvas.getHeight() / 2), 'center', 'center');
 
       var originalCanvas = this.canvas;
       canvas.add(this);


### PR DESCRIPTION
When dataurling an object let's center it using the canvas.getWidth() and canvas.getHeight(). The dimensions returned take in account the eventual retina scaling.

closes #2886
closes #2968