### PR TITLE
Apply viewport transform when calculating isTargetTransparent()

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -346,11 +346,14 @@
 
       target.hasBorders = target.transparentCorners = false;
 
+      ctx.save();
+      ctx.transform.apply(ctx, this.viewportTransform);
       if (shouldTransform) {
-        ctx.save();
         ctx.transform.apply(ctx, target.group.calcTransformMatrix());
       }
       target.render(ctx);
+      ctx.restore();
+
       target.active && target._renderControls(ctx);
 
       target.hasBorders = hasBorders;
@@ -358,7 +361,6 @@
 
       var isTransparent = fabric.util.isTransparent(
         ctx, x, y, this.targetFindTolerance);
-      shouldTransform && ctx.restore();
 
       this.clearContext(ctx);
 


### PR DESCRIPTION
This fixes a bug with how an interactive canvas with perPixelTargetFind behaves after being panned/zoomed.

## Version
1.6.2

## Test Case
http://jsfiddle.net/d10y74q7/5/

## Steps to reproduce
1. Turn perPixelTargetFind on for a Canvas instance
2. Modify the viewport of the canvas (pan or zoom)
3. Attempt to select objects of the interactive canvas

## Expected Behavior
Cursor should change to the move cursor when over opaque pixels, and clicking & dragging should move items.

## Actual Behavior
Objects can only be interacted with when the XY coordinates of the pointer are coincidentally over opaque pixels in the canvas with an unmodified viewport.
