### PR TITLE
Fix IText rendering to take viewportTransform into account

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -430,8 +430,8 @@
       this.hiddenTextarea.selectionEnd = this.selectionEnd;
       if (this.selectionStart === this.selectionEnd) {
         var p = this._calcTextareaPosition();
-        this.hiddenTextarea.style.left = (p.x * this.canvas.viewportTransform[0]) + 'px';
-        this.hiddenTextarea.style.top = (p.y * this.canvas.viewportTransform[3]) + 'px';
+        this.hiddenTextarea.style.left = p.x + 'px';
+        this.hiddenTextarea.style.top = p.y + 'px';
       }
     },
 
@@ -451,7 +451,9 @@
           m = this.calcTransformMatrix(),
           p = { x: boundaries.left + leftOffset, y: boundaries.top + boundaries.topOffset + charHeight };
       this.hiddenTextarea.style.fontSize = charHeight + 'px';
-      return fabric.util.transformPoint(p, m);
+      p = fabric.util.transformPoint(p, m);
+      p = fabric.util.transformPoint(p, this.getViewportTransform());
+      return p;
     },
 
     /**

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -430,8 +430,8 @@
       this.hiddenTextarea.selectionEnd = this.selectionEnd;
       if (this.selectionStart === this.selectionEnd) {
         var p = this._calcTextareaPosition();
-        this.hiddenTextarea.style.left = p.x + 'px';
-        this.hiddenTextarea.style.top = p.y + 'px';
+        this.hiddenTextarea.style.left = (p.x * this.canvas.viewportTransform[0]) + 'px';
+        this.hiddenTextarea.style.top = (p.y * this.canvas.viewportTransform[3]) + 'px';
       }
     },
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -14,8 +14,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
+    var vpt = this.getViewportTransform();
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + (p.y * this.canvas.viewportTransform[3]) + 'px; left: ' + (p.x * this.canvas.viewportTransform[0]) + 'px; opacity: 0;'
+    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + (p.y * vpt[3]) + 'px; left: ' + (p.x * vpt[0]) + 'px; opacity: 0;'
                                         + ' width: 0px; height: 0px; z-index: -999;';
     if (this.canvas) {
       this.canvas.lowerCanvasEl.parentNode.appendChild(this.hiddenTextarea);

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -16,7 +16,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
     var vpt = this.getViewportTransform();
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + (p.y * vpt[3]) + 'px; left: ' + (p.x * vpt[0]) + 'px; opacity: 0;'
+    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + (p.y * vpt[3]) + 'px; left: '
+                                        + (p.x * vpt[0]) + 'px; opacity: 0;'
                                         + ' width: 0px; height: 0px; z-index: -999;';
     if (this.canvas) {
       this.canvas.lowerCanvasEl.parentNode.appendChild(this.hiddenTextarea);

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -15,7 +15,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + p.y + 'px; left: ' + p.x + 'px; opacity: 0;'
+    this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + (p.y * this.canvas.viewportTransform[3]) + 'px; left: ' + (p.x * this.canvas.viewportTransform[0]) + 'px; opacity: 0;'
                                         + ' width: 0px; height: 0px; z-index: -999;';
     if (this.canvas) {
       this.canvas.lowerCanvasEl.parentNode.appendChild(this.hiddenTextarea);

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -497,7 +497,7 @@
       ctx.fillRect(
         boundaries.left + leftOffset,
         boundaries.top + boundaries.topOffset,
-        this.cursorWidth / this.scaleX,
+        this.cursorWidth / this.scaleX / this.canvas.viewportTransform[0],
         charHeight);
 
     },

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -487,6 +487,7 @@
           lineIndex = cursorLocation.lineIndex,
           charIndex = cursorLocation.charIndex,
           charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
+          scaleFactor = this.scaleX,
           leftOffset = (lineIndex === 0 && charIndex === 0)
                     ? this._getLineLeftOffset(this._getLineWidth(ctx, lineIndex))
                     : boundaries.leftOffset;
@@ -494,10 +495,14 @@
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
       ctx.globalAlpha = this.__isMousedown ? 1 : this._currentCursorOpacity;
 
+      if (this.canvas) {
+        scaleFactor *= this.canvas.getZoom();
+      }
+
       ctx.fillRect(
         boundaries.left + leftOffset,
         boundaries.top + boundaries.topOffset,
-        this.cursorWidth / this.scaleX / this.canvas.viewportTransform[0],
+        this.cursorWidth / scaleFactor,
         charHeight);
 
     },


### PR DESCRIPTION
When having a viewportTransform on the canvas IText fails to correctly render the cursor and the hidden area since it doesn't take the viewportTransform into account.

This patch fixes this, but I'm not entirely sure if I took the right approach.