### PR TITLE
Fix _isTargetTransparent to honor viewportTransform

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -342,15 +342,22 @@
       var hasBorders = target.hasBorders,
           transparentCorners = target.transparentCorners,
           ctx = this.contextCache,
-          shouldTransform = target.group && target.group === this.getActiveGroup();
+          shouldTransform = target.group && target.group === this.getActiveGroup(),
+          matrix = shouldTransform ? target.group.calcTransformMatrix() : [1, 0, 0, 1, 0, 0];
 
       target.hasBorders = target.transparentCorners = false;
 
       if (shouldTransform) {
         ctx.save();
-        ctx.transform.apply(ctx, target.group.calcTransformMatrix());
+        ctx.transform.apply(ctx, matrix);
       }
+
+      ctx.save();
+      ctx.transform.apply(ctx,
+        fabric.util.multiplyTransformMatrices(matrix, this.viewportTransform));
       target.render(ctx);
+      ctx.restore();
+
       target.active && target._renderControls(ctx);
 
       target.hasBorders = hasBorders;


### PR DESCRIPTION
When a viewportTransform is set the transparency detection does not work since it does not respect the viewportTransform when rendering the target onto the cache canvas.

This patch fixes this, but I'm not entirely sure if I took the right approach.