### PR TITLE
Object caching

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -341,7 +341,8 @@
       if (this.isEditing || !this.editable) {
         return;
       }
-
+      this._originalCaching = this.objectCaching;
+      this.objectCaching = false;
       if (this.canvas) {
         this.exitEditingOnOthers(this.canvas);
       }
@@ -507,7 +508,8 @@
       this.abortCursorAnimation();
       this._restoreEditingProps();
       this._currentCursorOpacity = 0;
-
+      this.objectCaching = this._originalCaching;
+      this.objectCaching && this.refreshCache();
       this.fire('editing:exited');
       isTextChanged && this.fire('modified');
       if (this.canvas) {

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -89,6 +89,14 @@
     _lastScaleY: 1,
 
     /**
+     * enable object caching
+     * since 1.6.3
+     * @type Boolean
+     * @default
+     */
+    objectCaching: false,
+
+    /**
      * Constructor
      * @param {HTMLImageElement | String} element Image element
      * @param {Object} [options] Options object

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -826,7 +826,11 @@
       this.cacheContext.scale(ratio, ratio);
     },
 
-    refreshCache: function() {
+    /**
+     * redraw the cache and update the cacheCanvas by request
+     * @param {Boolean} [noTransform] for pathgroup rendering purpouse, leave it to false.
+     */
+    refreshCache: function(noTransform) {
       var ctx = this.cacheContext,
           dim = this._getNonTransformedDimensions(),
           width = dim.x, height = dim.y;
@@ -837,7 +841,7 @@
         ctx.clearRect(-width / 2, -height / 2, width, height);
       }
       ctx.globalAlpha = 1;
-      this._cachingNeeds && this._cachingNeeds(ctx);
+      this._cachingNeeds && this._cachingNeeds(ctx, noTransform);
       this._draw(ctx);
       this.isCacheDirty = false;
     },
@@ -1143,7 +1147,7 @@
         this._updateCacheCanvas();
       }
       if (this.objectCaching && this.isCacheDirty) {
-        this.refreshCache();
+        this.refreshCache(noTransform);
       }
       ctx.save();
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -752,7 +752,34 @@
      * @default
      */
 
-    excludeFromExport:          false,
+    excludeFromExport:        false,
+
+    /**
+     * enable object caching
+     * since 1.6.3
+     * @type Boolean
+     * @default
+     */
+
+    caching:                   true,
+
+    /**
+     * Dirty cache flage
+     * since 1.6.3
+     * @type Boolean
+     * @default
+     */
+
+    isCacheDirty:                   true,
+
+    /**
+     * Canvas element used to store cache
+     * since 1.6.3
+     * @type CanvasElement
+     * @default
+     */
+
+    _cacheCanvasEl:              null,
 
     /**
      * List of properties to consider when checking if state
@@ -775,6 +802,37 @@
       if (options) {
         this.setOptions(options);
       }
+    },
+
+    /**
+     * @private
+     */
+    _createCacheCanvas: function() {
+      this._cacheCanvasEl = fabric.util.createCanvasElement();
+    },
+
+    /**
+     * @private
+     */
+    _updateCacheCanvas: function() {
+      var ratio = fabric.devicePixelRatio,
+          dim = this._getNonTransformedDimensions(),
+          width = dim.x * ratio,
+          height = dim.y * ratio;
+      this._cacheCanvasEl.width = width;
+      this._cacheCanvasEl.height = height;
+      this.cacheContext = this._cacheCanvasEl.getContext("2d");
+      this.cacheContext.translate(width/2, height/2);
+      this.cacheContext.scale(ratio, ratio);
+    },
+
+    refreshCache: function() {
+      var ctx = this.cacheContext,
+          dim = this._getNonTransformedDimensions(),
+          width = dim.x, height = dim.y;
+      ctx.clearRect(-width / 2, -height / 2, width, height);
+      ctx.globalAlpha = 1;
+      this._draw(ctx);
     },
 
     /**
@@ -1073,7 +1131,13 @@
       if ((this.width === 0 && this.height === 0) || !this.visible) {
         return;
       }
-
+      if (this.caching && !this._cacheCanvasEl) {
+        this._createCacheCanvas();
+        this._updateCacheCanvas();
+      }
+      if (this.caching && this.isCacheDirty) {
+        this.refreshCache();
+      }
       ctx.save();
 
       //setup fill rule for current object
@@ -1082,18 +1146,32 @@
       if (!noTransform) {
         this.transform(ctx);
       }
-      this._setStrokeStyles(ctx);
-      this._setFillStyles(ctx);
       if (this.transformMatrix) {
         ctx.transform.apply(ctx, this.transformMatrix);
       }
-      this._setOpacity(ctx);
       this._setShadow(ctx);
+      if (this.caching) {
+        this._drawCache(ctx, noTransform);
+      }
+      else {
+        this._draw(ctx, noTransform);
+      }
+      ctx.restore();
+    },
+
+
+    _draw: function(ctx, noTransform) {
+      this._setStrokeStyles(ctx);
+      this._setFillStyles(ctx);
+      this._setOpacity(ctx);
       this.clipTo && fabric.util.clipContext(this, ctx);
       this._render(ctx, noTransform);
       this.clipTo && ctx.restore();
+    },
 
-      ctx.restore();
+    _drawCache: function(ctx) {
+      var dim = this._getNonTransformedDimensions();
+      ctx.drawImage(this._cacheCanvasEl, -dim.x/2,  -dim.y/2);
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -761,7 +761,7 @@
      * @default
      */
 
-    caching:                   true,
+    objectCaching:            true,
 
     /**
      * Dirty cache flage
@@ -770,7 +770,7 @@
      * @default
      */
 
-    isCacheDirty:                   true,
+    isCacheDirty:             true,
 
     /**
      * Canvas element used to store cache
@@ -779,7 +779,7 @@
      * @default
      */
 
-    _cacheCanvasEl:              null,
+    _cacheCanvasEl:           null,
 
     /**
      * List of properties to consider when checking if state
@@ -830,9 +830,16 @@
       var ctx = this.cacheContext,
           dim = this._getNonTransformedDimensions(),
           width = dim.x, height = dim.y;
-      ctx.clearRect(-width / 2, -height / 2, width, height);
+      if (dim.x !== this._cacheCanvasEl.width || dim.y !== this._cacheCanvasEl.height) {
+        this._updateCacheCanvas();
+      }
+      else {
+        ctx.clearRect(-width / 2, -height / 2, width, height);
+      }
       ctx.globalAlpha = 1;
+      this._cachingNeeds && this._cachingNeeds(ctx);
       this._draw(ctx);
+      this.isCacheDirty = false;
     },
 
     /**
@@ -1131,11 +1138,11 @@
       if ((this.width === 0 && this.height === 0) || !this.visible) {
         return;
       }
-      if (this.caching && !this._cacheCanvasEl) {
+      if (this.objectCaching && !this._cacheCanvasEl) {
         this._createCacheCanvas();
         this._updateCacheCanvas();
       }
-      if (this.caching && this.isCacheDirty) {
+      if (this.objectCaching && this.isCacheDirty) {
         this.refreshCache();
       }
       ctx.save();
@@ -1150,7 +1157,7 @@
         ctx.transform.apply(ctx, this.transformMatrix);
       }
       this._setShadow(ctx);
-      if (this.caching) {
+      if (this.objectCaching) {
         this._drawCache(ctx, noTransform);
       }
       else {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -742,7 +742,6 @@
      * @type Boolean
      * @default
      */
-
     lockScalingFlip:          false,
 
     /**
@@ -751,7 +750,6 @@
      * @type Boolean
      * @default
      */
-
     excludeFromExport:        false,
 
     /**
@@ -760,7 +758,6 @@
      * @type Boolean
      * @default
      */
-
     objectCaching:            true,
 
     /**
@@ -769,7 +766,6 @@
      * @type Boolean
      * @default
      */
-
     isCacheDirty:             true,
 
     /**
@@ -778,7 +774,6 @@
      * @type CanvasElement
      * @default
      */
-
     _cacheCanvasEl:           null,
 
     /**

--- a/src/shapes/path_group.class.js
+++ b/src/shapes/path_group.class.js
@@ -36,6 +36,13 @@
     fill: '',
 
     /**
+     * Stroke width value, pathgroup has no stroke.
+     * @type Number
+     * @default
+     */
+    strokeWidth: 0,
+
+    /**
      * Constructor
      * @param {Array} paths
      * @param {Object} [options] Options object
@@ -102,21 +109,40 @@
         return;
       }
 
+      if (this.objectCaching && !this._cacheCanvasEl) {
+        this._createCacheCanvas();
+        this._updateCacheCanvas();
+      }
+      if (this.objectCaching && this.isCacheDirty) {
+        this.refreshCache();
+      }
+
       ctx.save();
 
       if (this.transformMatrix) {
         ctx.transform.apply(ctx, this.transformMatrix);
       }
       this.transform(ctx);
-
       this._setShadow(ctx);
+
+      if (this.objectCaching) {
+        this._drawCache(ctx);
+      }
+      else {
+        this._draw(ctx, true);
+      }
+
+      ctx.restore();
+    },
+
+    _draw: function(ctx, noTransform) {
       this.clipTo && fabric.util.clipContext(this, ctx);
       ctx.translate(-this.width/2, -this.height/2);
       for (var i = 0, l = this.paths.length; i < l; ++i) {
+        this.paths[i].objectCaching = false;
         this.paths[i].render(ctx, true);
       }
       this.clipTo && ctx.restore();
-      ctx.restore();
     },
 
     /**

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -147,6 +147,14 @@
 
     /**
      * @private
+     * per class specific caching needs
+     */
+    _cachingNeeds: function(ctx, noTranform) {
+      noTransform || ctx.translate(this.pathOffset.x, this.pathOffset.y);
+    },
+
+    /**
+     * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     commonRender: function(ctx, noTransform) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -371,6 +371,8 @@
      */
     _render: function(ctx) {
       this._renderTextBackground(ctx);
+      //this command is actually duplicated for text based class
+      this._setFillStyles(ctx);
       this._renderText(ctx);
       this._renderTextDecoration(ctx);
     },
@@ -821,11 +823,11 @@
         return;
       }
 
-      if (this.caching && !this._cacheCanvasEl) {
+      if (this.objectCaching && !this._cacheCanvasEl) {
         this._createCacheCanvas();
         this._updateCacheCanvas();
       }
-      if (this.caching && this.isCacheDirty) {
+      if (this.objectCaching && this.isCacheDirty) {
         this.refreshCache();
       }
 
@@ -847,26 +849,25 @@
         ctx.translate(this.left, this.top);
       }
       this._setShadow(ctx);
-      if (this.caching) {
+      if (this.objectCaching) {
         this._drawCache(ctx, noTransform);
       }
       else {
         this._draw(ctx, noTransform);
       }
       ctx.restore();
+      //this.ctx = ctx;
     },
 
-    refreshCache: function() {
-      var ctx = this.cacheContext,
-          width = this.width, height = this.height;
-      ctx.clearRect(-width / 2, -height / 2, width, height);
-      ctx.globalAlpha = 1;
+    /**
+     * @private
+     * per class specific caching needs
+     */
+    _cachingNeeds: function(ctx) {
       this._setTextStyles(ctx);
       if (this._shouldClearCache()) {
         this._initDimensions(ctx);
       }
-      this._draw(ctx);
-      this.isCacheDirty = false;
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -828,7 +828,7 @@
         this._updateCacheCanvas();
       }
       if (this.objectCaching && this.isCacheDirty) {
-        this.refreshCache();
+        this.refreshCache(noTransform);
       }
 
       ctx.save();

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -777,6 +777,7 @@ test('toDataURL & reference to canvas', function() {
     ok(typeof object._setLineDash === 'function');
 
     canvas.add(object);
+    object.objectCache = false;
     object.strokeDashArray = [3, 2, 1];
     equal(object.strokeDashArray.length, 3, 'strokeDash array is odd');
     canvas.renderAll();

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -777,7 +777,7 @@ test('toDataURL & reference to canvas', function() {
     ok(typeof object._setLineDash === 'function');
 
     canvas.add(object);
-    object.objectCache = false;
+    object.objectCaching = false;
     object.strokeDashArray = [3, 2, 1];
     equal(object.strokeDashArray.length, 3, 'strokeDash array is odd');
     canvas.renderAll();


### PR DESCRIPTION
Still lot of work to do, basically working.

Object get rendered from canvas cache copy if objectCaching is true.
For usability purpouse iText automatically disable and rebuild cache on edit enter - exit
Speed improvements: noticeable just with big loads ( 200 complicated iText, you go from heavy shutter to smooth)
Cache copy does not include shadow and it will not for now.

TODO:
fix group,
decide what to do with automatic cache clearing, if use object statefull properties ( a subset of them ) to autoclear cache.
implement scaling
possible tests about the caching canvas dimensions

DONE:
pathgroups
fix polygon
do not cache images.

closes #814 
closes #318