### PR TITLE
Grouped object selection/manipulation

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -947,7 +947,7 @@
       }
 
       var pointer = this.getPointer(e, true);
-      this.targets = [ ]
+      this.targets = [ ];
 
       if (this._isLastRenderedObject(pointer)) {
         return this.lastRenderedWithControls;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -474,14 +474,12 @@
 
       var pointer = this.getPointer(e),
           unzoomedPointer = this.getPointer(e, true),
-          parentGroup = target.group,
           corner, action, origin;
 
-      while (parentGroup) {
-        pointer = this._normalizePointer(parentGroup, pointer);
-        unzoomedPointer = this._normalizePointer(parentGroup, unzoomedPointer);
-        parentGroup = parentGroup.group;
-      }
+      target.bubbleThroughGroups(function(g) {
+        pointer = this._normalizePointer(g, pointer);
+        unzoomedPointer = this._normalizePointer(g, unzoomedPointer);
+      }, this);
 
       corner = target._findTargetCorner(unzoomedPointer);
       action = this._getActionFromCorner(target, corner, e);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -295,7 +295,7 @@
      * Checks if point is contained within an area of given object
      * @param {Event} e Event object
      * @param {fabric.Object} target Object to test against
-     * @param {Object} point x,y object of point coordinates we want to check.
+     * @param {Object} [point] x,y object of point coordinates we want to check.
      * @return {Boolean} true if point is contained within an area of given object
      */
     containsPoint: function (e, target, point) {

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -946,20 +946,24 @@
         return;
       }
 
-      var pointer = this.getPointer(e, true);
-      this.targets = [ ];
-
-      if (this._isLastRenderedObject(pointer)) {
-        return this.lastRenderedWithControls;
-      }
-
       // first check current group (if one exists)
+      // avtive group does not check sub targets like normal groups.
+      // if active group just exits.
       var activeGroup = this.getActiveGroup();
-      if (!skipGroup && this._checkTarget(pointer, activeGroup)) {
+      if (activeGroup && !skipGroup && this._checkTarget(pointer, activeGroup)) {
         return activeGroup;
       }
 
-      var target = this._searchPossibleTargets(this._objects, pointer);
+	  
+      var pointer = this.getPointer(e, true),
+          objects = this._objects;
+      this.targets = [ ];
+
+      if (this._isLastRenderedObject(pointer)) {
+        objects = [this.lastRenderedWithControls];
+      }
+
+      var target = this._searchPossibleTargets(objects, pointer);
       this._fireOverOutEvents(target, e);
       return target;
     },
@@ -1020,7 +1024,7 @@
           target = objects[i];
           if (target.type === 'group' && target.subTargetCheck) {
             normalizedPointer = this._normalizePointer(target, pointer);
-            subTarget = this._searchPossibleTargets(normalizedPointer, target._objects);
+            subTarget = this._searchPossibleTargets(target._objects, normalizedPointer);
             subTarget && this.targets.push(subTarget);
           }
           break;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -954,7 +954,6 @@
         return activeGroup;
       }
 
-	  
       var pointer = this.getPointer(e, true),
           objects = this._objects;
       this.targets = [ ];

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -473,9 +473,17 @@
       }
 
       var pointer = this.getPointer(e),
-          corner = target._findTargetCorner(this.getPointer(e, true)),
-          action = this._getActionFromCorner(target, corner, e),
-          origin = this._getOriginFromCorner(target, corner);
+          unzoomedPointer = this.getPointer(e, true),
+          corner, action, origin;
+
+      if (target.group) {
+        pointer = this._normalizePointer(target.group, pointer);
+        unzoomedPointer = this._normalizePointer(target.group, unzoomedPointer)
+      }
+
+      corner = target._findTargetCorner(unzoomedPointer);
+      action = this._getActionFromCorner(target, corner, e);
+      origin = this._getOriginFromCorner(target, corner);
 
       this._currentTransform = {
         target: target,

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -478,7 +478,7 @@
 
       if (target.group) {
         pointer = this._normalizePointer(target.group, pointer);
-        unzoomedPointer = this._normalizePointer(target.group, unzoomedPointer)
+        unzoomedPointer = this._normalizePointer(target.group, unzoomedPointer);
       }
 
       corner = target._findTargetCorner(unzoomedPointer);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1029,7 +1029,7 @@
       while (i--) {
         if (this._checkTarget(pointer, objects[i])) {
           target = objects[i];
-          if (target.type === 'group' && target.subTargetCheck) {
+          if (target instanceof fabric.Group && target.subTargetCheck) {
             normalizedPointer = this._normalizePointer(target, pointer);
             subTarget = this._searchPossibleTargets(target._objects, normalizedPointer);
             subTarget && this.targets.push(subTarget);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -295,12 +295,19 @@
      * Checks if point is contained within an area of given object
      * @param {Event} e Event object
      * @param {fabric.Object} target Object to test against
+     * @param {Object} point x,y object of point coordinates we want to check.
      * @return {Boolean} true if point is contained within an area of given object
      */
-    containsPoint: function (e, target) {
-      var pointer = this.getPointer(e, true),
+    containsPoint: function (e, target, point) {
+      var pointer = point || this.getPointer(e, true),
           xy = this._normalizePointer(target, pointer);
 
+      if (target.group && target.group === this.getActiveGroup()) {
+        xy = this._normalizePointer(target.group, pointer);
+      }
+      else {
+        xy = { x: pointer.x, y: pointer.y };
+      }
       // http://www.geog.ubc.ca/courses/klink/gis.notes/ncgia/u32.html
       // http://idav.ucdavis.edu/~okreylos/TAship/Spring2000/PointInPolygon.html
       return (target.containsPoint(xy) || target._findTargetCorner(pointer));
@@ -310,24 +317,17 @@
      * @private
      */
     _normalizePointer: function (object, pointer) {
-      var activeGroup = this.getActiveGroup(),
-          isObjectInGroup = (
-            activeGroup &&
-            object.type !== 'group' &&
-            activeGroup.contains(object)),
-          lt, m;
+      var lt, m;
 
-      if (isObjectInGroup) {
-        m = fabric.util.multiplyTransformMatrices(
-              this.viewportTransform,
-              activeGroup.calcTransformMatrix());
+      m = fabric.util.multiplyTransformMatrices(
+            this.viewportTransform,
+            object.calcTransformMatrix());
 
-        m = fabric.util.invertTransform(m);
-        pointer = fabric.util.transformPoint(pointer, m , false);
-        lt = fabric.util.transformPoint(activeGroup.getCenterPoint(), m , false);
-        pointer.x -= lt.x;
-        pointer.y -= lt.y;
-      }
+      m = fabric.util.invertTransform(m);
+      pointer = fabric.util.transformPoint(pointer, m , false);
+      lt = fabric.util.transformPoint(object.getCenterPoint(), m , false);
+      pointer.x -= lt.x;
+      pointer.y -= lt.y;
       return { x: pointer.x, y: pointer.y };
     },
 
@@ -927,38 +927,40 @@
     /**
      * @private
      */
-    _isLastRenderedObject: function(e) {
+    _isLastRenderedObject: function(pointer) {
+      var lastRendered = this.lastRenderedWithControls;
       return (
-        this.controlsAboveOverlay &&
-        this.lastRenderedObjectWithControlsAboveOverlay &&
-        this.lastRenderedObjectWithControlsAboveOverlay.visible &&
-        this.containsPoint(e, this.lastRenderedObjectWithControlsAboveOverlay) &&
-        this.lastRenderedObjectWithControlsAboveOverlay._findTargetCorner(this.getPointer(e, true)));
+        lastRendered &&
+        lastRendered.visible &&
+        (this.containsPoint(null, lastRendered, pointer) ||
+        lastRendered._findTargetCorner(pointer)));
     },
 
     /**
      * Method that determines what object we are clicking on
      * @param {Event} e mouse event
-     * @param {Boolean} skipGroup when true, group is skipped and only objects are traversed through
+     * @param {Boolean} skipGroup when true, activeGroup is skipped and only objects are traversed through
      */
     findTarget: function (e, skipGroup) {
       if (this.skipTargetFind) {
         return;
       }
 
-      if (this._isLastRenderedObject(e)) {
-        return this.lastRenderedObjectWithControlsAboveOverlay;
+      var pointer = this.getPointer(e, true);
+      this.targets = [ ]
+
+      if (this._isLastRenderedObject(pointer)) {
+        return this.lastRenderedWithControls;
       }
 
       // first check current group (if one exists)
       var activeGroup = this.getActiveGroup();
-      if (!skipGroup && this._checkTarget(e, activeGroup, this.getPointer(e, true))) {
+      if (!skipGroup && this._checkTarget(pointer, activeGroup)) {
         return activeGroup;
       }
 
-      var target = this._searchPossibleTargets(e, skipGroup);
+      var target = this._searchPossibleTargets(this._objects, pointer);
       this._fireOverOutEvents(target, e);
-
       return target;
     },
 
@@ -987,11 +989,11 @@
     /**
      * @private
      */
-    _checkTarget: function(e, obj, pointer) {
+    _checkTarget: function(pointer, obj) {
       if (obj &&
           obj.visible &&
           obj.evented &&
-          this.containsPoint(e, obj)){
+          this.containsPoint(null, obj, pointer)){
         if ((this.perPixelTargetFind || obj.perPixelTargetFind) && !obj.isEditing) {
           var isTransparent = this.isTargetTransparent(obj, pointer.x, pointer.y);
           if (!isTransparent) {
@@ -1007,22 +1009,23 @@
     /**
      * @private
      */
-    _searchPossibleTargets: function(e, skipGroup) {
+    _searchPossibleTargets: function(objects, pointer) {
 
       // Cache all targets where their bounding box contains point.
-      var target,
-          pointer = this.getPointer(e, true),
-          i = this._objects.length;
+      var target, i = objects.length, normalizedPointer, subTarget;
       // Do not check for currently grouped objects, since we check the parent group itself.
       // untill we call this function specifically to search inside the activeGroup
       while (i--) {
-        if ((!this._objects[i].group || skipGroup) && this._checkTarget(e, this._objects[i], pointer)){
-          this.relatedTarget = this._objects[i];
-          target = this._objects[i];
+        if (this._checkTarget(pointer, objects[i])) {
+          target = objects[i];
+          if (target.type === 'group' && target.subTargetCheck) {
+            normalizedPointer = this._normalizePointer(target, pointer);
+            subTarget = this._searchPossibleTargets(normalizedPointer, target._objects);
+            subTarget && this.targets.push(subTarget);
+          }
           break;
         }
       }
-
       return target;
     },
 
@@ -1353,7 +1356,7 @@
           continue;
         }
         this._objects[i]._renderControls(ctx);
-        this.lastRenderedObjectWithControlsAboveOverlay = this._objects[i];
+        this.lastRenderedWithControls = this._objects[i];
       }
     }
   });

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1354,12 +1354,22 @@
      * @private
      */
     _drawObjectsControls: function(ctx) {
-      for (var i = 0, len = this._objects.length; i < len; ++i) {
-        if (!this._objects[i] || !this._objects[i].active) {
+      this._drawCollectionControls(ctx, this);
+    },
+
+    /**
+     * @private
+     */
+    _drawCollectionControls: function(ctx, collection) {
+      for (var i = 0, len = collection._objects.length; i < len; ++i) {
+        if (collection._objects[i] && collection._objects[i]._objects) {
+          this._drawCollectionControls(ctx, collection._objects[i]);
+        }
+        if (!collection._objects[i] || !collection._objects[i].active) {
           continue;
         }
-        this._objects[i]._renderControls(ctx);
-        this.lastRenderedWithControls = this._objects[i];
+        collection._objects[i]._renderControls(ctx);
+        this.lastRenderedWithControls = collection._objects[i];
       }
     }
   });

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -474,11 +474,13 @@
 
       var pointer = this.getPointer(e),
           unzoomedPointer = this.getPointer(e, true),
+          parentGroup = target.group,
           corner, action, origin;
 
-      if (target.group) {
-        pointer = this._normalizePointer(target.group, pointer);
-        unzoomedPointer = this._normalizePointer(target.group, unzoomedPointer);
+      while (parentGroup) {
+        pointer = this._normalizePointer(parentGroup, pointer);
+        unzoomedPointer = this._normalizePointer(parentGroup, unzoomedPointer);
+        parentGroup = parentGroup.group;
       }
 
       corner = target._findTargetCorner(unzoomedPointer);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -442,7 +442,7 @@
 
       var target = this.findTarget(e),
           pointer = this.getPointer(e, true),
-          deepTarget;
+          deepTargetHandled = false;
 
       // save pointer for check in __onMouseUp event
       this._previousPointer = pointer;
@@ -459,27 +459,40 @@
       }
 
       for (var i = this.targets.length - 1; i >= 0; i--) {
-        deepTarget = this.targets[i];
-
-        if (deepTarget.selectable && (deepTarget.__corner || !this._shouldGroup(e, deepTarget))) {
-          if (deepTarget !== target) {
-            deepTarget.group.update();
-          }
-          this._beforeTransform(e, deepTarget);
-          this._setupCurrentTransform(e, deepTarget);
+        if (this._handleTargetMouseDown(e, this.targets[i], target)) {
+          deepTargetHandled = true;
           break;
         }
       }
 
-      if (deepTarget) {
-        if (deepTarget !== this.getActiveGroup() && deepTarget !== this.getActiveObject()) {
-          this.deactivateAll();
-          deepTarget.selectable && this.setActiveObject(deepTarget, e);
-        }
+      if (target && !deepTargetHandled) {
+        this._handleTargetMouseDown(e, target, target);
       }
+
       this._handleEvent(e, 'down');
       // we must renderAll so that active image is placed on the top canvas
       shouldRender && this.renderAll();
+    },
+
+    /**
+     * @private
+     */
+    _handleTargetMouseDown: function(e, target, topTarget) {
+      if (target.selectable && (target.__corner || !this._shouldGroup(e, target))) {
+        if (target !== topTarget) {
+          target.group.update();
+        }
+        this._beforeTransform(e, target);
+        this._setupCurrentTransform(e, target);
+
+        if (target !== this.getActiveGroup() && target !== this.getActiveObject()) {
+          this.deactivateAll();
+          target.selectable && this.setActiveObject(target, e);
+        }
+        return true;
+      }
+
+      return false;
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -324,8 +324,7 @@
     _finalizeCurrentTransform: function() {
 
       var transform = this._currentTransform,
-          target = transform.target,
-          parentGroup = target.group;
+          target = transform.target;
 
       if (target._scaling) {
         target._scaling = false;
@@ -339,13 +338,12 @@
         target.fire('modified');
       }
 
-      while (parentGroup) {
-        parentGroup.update();
-        parentGroup.setCoords();
-        this.fire('object:modified', { target: parentGroup });
-        parentGroup.fire('modified');
-        parentGroup = parentGroup.group;
-      }
+      target.bubbleThroughGroups(function(g) {
+        g.update();
+        g.setCoords();
+        this.fire('object:modified', { target: g });
+        g.fire('modified');
+      }, this);
     },
 
     /**
@@ -627,13 +625,11 @@
     _transformObject: function(e) {
       var pointer = this.getPointer(e),
           transform = this._currentTransform,
-          target = transform.target,
-          parentGroup = target.group;
+          target = transform.target;
 
-      while (parentGroup) {
-        pointer = this._normalizePointer(parentGroup, pointer);
-        parentGroup = parentGroup.group;
-      }
+      target.bubbleThroughGroups(function(g) {
+        pointer = this._normalizePointer(g, pointer);
+      }, this);
 
       transform.reset = false,
       target.isMoving = true;
@@ -750,13 +746,11 @@
       else {
         var activeGroup = this.getActiveGroup(),
             pointer = this.getPointer(e, true),
-            parentGroup = target.group,
             corner;
 
-        while (parentGroup) {
-          pointer = this._normalizePointer(parentGroup, pointer);
-          parentGroup = parentGroup.group;
-        }
+        target.bubbleThroughGroups(function(g) {
+          pointer = this._normalizePointer(g, pointer);
+        }, this);
 
         // only show proper corner when group selection is not active
         corner = target._findTargetCorner

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -600,12 +600,15 @@
         this.renderTop();
       }
       else if (!this._currentTransform) {
-        this.findTarget(e);
+        target = this.findTarget(e);
 
         if (this.targets.length) {
           for (var i = 0; i < this.targets.length; i++) {
             this._setCursorFromEvent(e, this.targets[i]);
           }
+        }
+        else if (target) {
+          this._setCursorFromEvent(e, target);
         }
         else {
           this._setCursorFromEvent(e, null);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -750,10 +750,12 @@
       else {
         var activeGroup = this.getActiveGroup(),
             pointer = this.getPointer(e, true),
+            parentGroup = target.group,
             corner;
 
-        if (target.group) {
-          pointer = this._normalizePointer(target.group, pointer);
+        while (parentGroup) {
+          pointer = this._normalizePointer(parentGroup, pointer);
+          parentGroup = parentGroup.group;
         }
 
         // only show proper corner when group selection is not active

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -304,7 +304,7 @@
      * Handle event firing for target and subtargets
      * @param {Event} e event from mouse
      * @param {String} eventType event to fire (up, down or move)
-     * @param {fabric.Object} target receiving event
+     * @param {fabric.Object} targetObj receiving event
      */
     _handleEvent: function(e, eventType, targetObj) {
       var target = targetObj || this.findTarget(e),

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -627,10 +627,12 @@
     _transformObject: function(e) {
       var pointer = this.getPointer(e),
           transform = this._currentTransform,
-          target = transform.target;
+          target = transform.target,
+          parentGroup = target.group;
 
-      if (target.group) {
-        pointer = this._normalizePointer(target.group, pointer);
+      while (parentGroup) {
+        pointer = this._normalizePointer(parentGroup, pointer);
+        parentGroup = parentGroup.group;
       }
 
       transform.reset = false,

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -458,15 +458,15 @@
         target = this.getActiveGroup();
       }
 
-      for (var i = this.targets.length - 1; i >= 0; i--) {
-        if (this._handleTargetMouseDown(e, this.targets[i], target)) {
+      for (var i = 0; i < this.targets.length; i++) {
+        if (this._handleTargetMouseDown(e, this.targets[i])) {
           deepTargetHandled = true;
           break;
         }
       }
 
       if (target && !deepTargetHandled) {
-        this._handleTargetMouseDown(e, target, target);
+        this._handleTargetMouseDown(e, target);
       }
 
       this._handleEvent(e, 'down');
@@ -477,9 +477,9 @@
     /**
      * @private
      */
-    _handleTargetMouseDown: function(e, target, topTarget) {
+    _handleTargetMouseDown: function(e, target) {
       if (target.selectable && (target.__corner || !this._shouldGroup(e, target))) {
-        if (target !== topTarget) {
+        if (target.group) {
           target.group.update();
         }
         this._beforeTransform(e, target);
@@ -603,7 +603,7 @@
         target = this.findTarget(e);
 
         if (this.targets.length) {
-          for (var i = 0; i < this.targets.length; i++) {
+          for (var i = this.targets.length - 1; i >= 0; i--) {
             this._setCursorFromEvent(e, this.targets[i]);
           }
         }

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -303,17 +303,18 @@
     /**
      * Handle event firing for target and subtargets
      * @param {Event} e event from mouse
-     * @param {fabric.Object} target receiving event
      * @param {String} eventType event to fire (up, down or move)
+     * @param {fabric.Object} target receiving event
      */
     _handleEvent: function(e, eventType, targetObj) {
       var target = targetObj || this.findTarget(e),
-          options = { e: e, target: target };
+          targets = this.targets,
+          options = { e: e, target: target, subTargets: targets };
 
       this.fire('mouse:' + eventType, options);
       target && target.fire('mouse' + eventType, options);
-      for (var i = 0; i < this.targets.length; i++) {
-        this.targets[i].fire('mouse' + eventType, options);
+      for (var i = 0; i < targets.length; i++) {
+        targets[i].fire('mouse' + eventType, options);
       }
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -341,6 +341,7 @@
 
       while (group) {
         group.addWithUpdate();
+        group.setCoords();
         this.fire('object:modified', { target: group });
         group.fire('modified');
         group = group.group;

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -325,7 +325,7 @@
 
       var transform = this._currentTransform,
           target = transform.target,
-          group = target.group;
+          parentGroup = target.group;
 
       if (target._scaling) {
         target._scaling = false;
@@ -339,12 +339,12 @@
         target.fire('modified');
       }
 
-      while (group) {
-        group.update();
-        group.setCoords();
-        this.fire('object:modified', { target: group });
-        group.fire('modified');
-        group = group.group;
+      while (parentGroup) {
+        parentGroup.update();
+        parentGroup.setCoords();
+        this.fire('object:modified', { target: parentGroup });
+        parentGroup.fire('modified');
+        parentGroup = parentGroup.group;
       }
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -587,8 +587,16 @@
         this.renderTop();
       }
       else if (!this._currentTransform) {
-        target = this.findTarget(e);
-        this._setCursorFromEvent(e, target);
+        this.findTarget(e);
+
+        if (this.targets.length) {
+          for (var i = 0; i < this.targets.length; i++) {
+            this._setCursorFromEvent(e, this.targets[i]);
+          }
+        }
+        else {
+          this._setCursorFromEvent(e, null);
+        }
       }
       else {
         this._transformObject(e);
@@ -723,10 +731,17 @@
       }
       else {
         var activeGroup = this.getActiveGroup(),
-            // only show proper corner when group selection is not active
-            corner = target._findTargetCorner
-                      && (!activeGroup || !activeGroup.contains(target))
-                      && target._findTargetCorner(this.getPointer(e, true));
+            pointer = this.getPointer(e, true),
+            corner;
+
+        if (target.group) {
+          pointer = this._normalizePointer(target.group, pointer);
+        }
+
+        // only show proper corner when group selection is not active
+        corner = target._findTargetCorner
+                  && (!activeGroup || !activeGroup.contains(target))
+                  && target._findTargetCorner(pointer);
 
         if (!corner) {
           this.setCursor(hoverCursor);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -340,7 +340,7 @@
       }
 
       while (group) {
-        group.addWithUpdate();
+        group.update();
         group.setCoords();
         this.fire('object:modified', { target: group });
         group.fire('modified');
@@ -463,7 +463,7 @@
 
         if (deepTarget.selectable && (deepTarget.__corner || !this._shouldGroup(e, deepTarget))) {
           if (deepTarget !== target) {
-            deepTarget.group.addWithUpdate();
+            deepTarget.group.update();
           }
           this._beforeTransform(e, deepTarget);
           this._setupCurrentTransform(e, deepTarget);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -602,10 +602,15 @@
      */
     _transformObject: function(e) {
       var pointer = this.getPointer(e),
-          transform = this._currentTransform;
+          transform = this._currentTransform,
+          target = transform.target;
+
+      if (target.group) {
+        pointer = this._normalizePointer(target.group, pointer);
+      }
 
       transform.reset = false,
-      transform.target.isMoving = true;
+      target.isMoving = true;
 
       this._beforeScaleTransform(e, transform);
       this._performTransformAction(e, transform, pointer);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -285,23 +285,36 @@
         target.isMoving = false;
       }
 
+      this._handleCursorAndEvent(e, target, 'up');
       shouldRender && this.renderAll();
-
-      this._handleCursorAndEvent(e, target);
     },
 
-    _handleCursorAndEvent: function(e, target) {
+    /**
+     * set cursor for mouse up and handle mouseUp event
+     * @param {Event} e event from mouse
+     * @param {fabric.Object} target receiving event
+     * @param {String} eventType event to fire (up, down or move)
+     */
+    _handleCursorAndEvent: function(e, target, eventType) {
       this._setCursorFromEvent(e, target);
+      this._handleEvent(e, eventType, target);
+    },
 
-      // Can't find any reason, disabling for now
-      // TODO: why are we doing this?
-      /* var _this = this;
-      setTimeout(function () {
-        _this._setCursorFromEvent(e, target);
-      }, 50); */
+    /**
+     * Handle event firing for target and subtargets
+     * @param {Event} e event from mouse
+     * @param {fabric.Object} target receiving event
+     * @param {String} eventType event to fire (up, down or move)
+     */
+    _handleEvent: function(e, eventType, targetObj) {
+      var target = targetObj || this.findTarget(e),
+          options = { e: e, target: target };
 
-      this.fire('mouse:up', { target: target, e: e });
-      target && target.fire('mouseup', { e: e });
+      this.fire('mouse:' + eventType, options);
+      target && target.fire('mouse' + eventType, options);
+      for (var i = 0; i < this.targets.length; i++) {
+        this.targets[i].fire('mouse' + eventType, options)
+      }
     },
 
     /**
@@ -361,12 +374,7 @@
       var ivt = fabric.util.invertTransform(this.viewportTransform),
           pointer = fabric.util.transformPoint(this.getPointer(e, true), ivt);
       this.freeDrawingBrush.onMouseDown(pointer);
-      this.fire('mouse:down', { e: e });
-
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mousedown', { e: e, target: target });
-      }
+      this._handleEvent(e, 'down');
     },
 
     /**
@@ -380,12 +388,7 @@
         this.freeDrawingBrush.onMouseMove(pointer);
       }
       this.setCursor(this.freeDrawingCursor);
-      this.fire('mouse:move', { e: e });
-
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mousemove', { e: e, target: target });
-      }
+      this._handleEvent(e, 'move');
     },
 
     /**
@@ -398,12 +401,7 @@
         this.contextTop.restore();
       }
       this.freeDrawingBrush.onMouseUp();
-      this.fire('mouse:up', { e: e });
-
-      var target = this.findTarget(e);
-      if (typeof target !== 'undefined') {
-        target.fire('mouseup', { e: e, target: target });
-      }
+      this._handleEvent(e, 'up');
     },
 
     /**
@@ -460,11 +458,9 @@
           target.selectable && this.setActiveObject(target, e);
         }
       }
+      this._handleEvent(e, 'down');
       // we must renderAll so that active image is placed on the top canvas
       shouldRender && this.renderAll();
-
-      this.fire('mouse:down', { target: target, e: e });
-      target && target.fire('mousedown', { e: e });
     },
 
     /**
@@ -578,9 +574,7 @@
       else {
         this._transformObject(e);
       }
-
-      this.fire('mouse:move', { target: target, e: e });
-      target && target.fire('mousemove', { e: e });
+      this._handleEvent(e, 'move');
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -313,7 +313,7 @@
       this.fire('mouse:' + eventType, options);
       target && target.fire('mouse' + eventType, options);
       for (var i = 0; i < this.targets.length; i++) {
-        this.targets[i].fire('mouse' + eventType, options)
+        this.targets[i].fire('mouse' + eventType, options);
       }
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -462,6 +462,9 @@
         deepTarget = this.targets[i];
 
         if (deepTarget.selectable && (deepTarget.__corner || !this._shouldGroup(e, deepTarget))) {
+          if (deepTarget !== target) {
+            deepTarget.group.addWithUpdate();
+          }
           this._beforeTransform(e, deepTarget);
           this._setupCurrentTransform(e, deepTarget);
           break;

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -324,7 +324,8 @@
     _finalizeCurrentTransform: function() {
 
       var transform = this._currentTransform,
-          target = transform.target;
+          target = transform.target,
+          group = target.group;
 
       if (target._scaling) {
         target._scaling = false;
@@ -336,6 +337,13 @@
       if (transform.actionPerformed || (this.stateful && target.hasStateChanged())) {
         this.fire('object:modified', { target: target });
         target.fire('modified');
+      }
+
+      while (group) {
+        group.addWithUpdate();
+        this.fire('object:modified', { target: group });
+        group.fire('modified');
+        group = group.group;
       }
     },
 
@@ -432,7 +440,8 @@
       }
 
       var target = this.findTarget(e),
-          pointer = this.getPointer(e, true);
+          pointer = this.getPointer(e, true),
+          deepTarget;
 
       // save pointer for check in __onMouseUp event
       this._previousPointer = pointer;
@@ -448,15 +457,20 @@
         target = this.getActiveGroup();
       }
 
-      if (target) {
-        if (target.selectable && (target.__corner || !shouldGroup)) {
-          this._beforeTransform(e, target);
-          this._setupCurrentTransform(e, target);
-        }
+      for (var i = this.targets.length - 1; i >= 0; i--) {
+        deepTarget = this.targets[i];
 
-        if (target !== this.getActiveGroup() && target !== this.getActiveObject()) {
+        if (deepTarget.selectable && (deepTarget.__corner || !this._shouldGroup(e, deepTarget))) {
+          this._beforeTransform(e, deepTarget);
+          this._setupCurrentTransform(e, deepTarget);
+          break;
+        }
+      }
+
+      if (deepTarget) {
+        if (deepTarget !== this.getActiveGroup() && deepTarget !== this.getActiveObject()) {
           this.deactivateAll();
-          target.selectable && this.setActiveObject(target, e);
+          deepTarget.selectable && this.setActiveObject(deepTarget, e);
         }
       }
       this._handleEvent(e, 'down');

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -24,18 +24,17 @@
      * @param {fabric.Object} target
      */
     _handleGrouping: function (e, target) {
+      var activeGroup = this.getActiveGroup();
 
-      if (target === this.getActiveGroup()) {
-
-        // if it's a group, find target again, this time skipping group
+      if (target === activeGroup) {
+        // if it's a group, find target again, using activeGroup objects
         target = this.findTarget(e, true);
-
         // if even object is not found, bail out
-        if (!target || target.isType('group')) {
+        if (!target) {
           return;
         }
       }
-      if (this.getActiveGroup()) {
+      if (activeGroup) {
         this._updateActiveGroup(target, e);
       }
       else {

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -102,7 +102,7 @@
           groupObjects = isActiveLower
             ? [ this._activeObject, target ]
             : [ target, this._activeObject ];
-
+      this._activeObject.isEditing && this._activeObject.exitEditing();
       return new fabric.Group(groupObjects, {
         canvas: this
       });

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -80,7 +80,7 @@
       if (this._activeObject && target !== this._activeObject) {
 
         var group = this._createGroup(target);
-        group.addWithUpdate();
+        group.update();
 
         this.setActiveGroup(group);
         this._activeObject = null;
@@ -124,7 +124,7 @@
         group = new fabric.Group(group.reverse(), {
           canvas: this
         });
-        group.addWithUpdate();
+        group.update();
         this.setActiveGroup(group, e);
         group.saveCoords();
         this.fire('selection:created', { target: group });

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -87,6 +87,9 @@
      * @return {Boolean} true if point is inside the object
      */
     containsPoint: function(point) {
+      if (!this.oCoords) {
+        this.setCoords();
+      }
       var lines = this._getImageLines(this.oCoords),
           xPoints = this._findCrossPoints(point, lines);
 

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -292,10 +292,17 @@
      * @chainable
      */
     setCoords: function() {
+      this._setCoords();
+      this._setCoords(true);
+      return this;
+    },
+
+    _setCoords: function(normalized) {
       var theta = degreesToRadians(this.angle),
           vpt = this.getViewportTransform(),
           dim = this._calculateCurrentDimensions(),
-          currentWidth = dim.x, currentHeight = dim.y;
+          currentWidth = dim.x, currentHeight = dim.y,
+          oCoords;
 
       // If width is negative, make postive. Fixes path selection issue
       if (currentWidth < 0) {
@@ -310,7 +317,7 @@
           offsetY = Math.sin(_angle + theta) * _hypotenuse,
 
           // offset added for rotate and scale actions
-          coords = fabric.util.transformPoint(this.getCenterPoint(), vpt),
+          coords = fabric.util.transformPoint(this.getCenterPoint(normalized), vpt),
           tl  = new fabric.Point(coords.x - offsetX, coords.y - offsetY),
           tr  = new fabric.Point(tl.x + (currentWidth * cosTh), tl.y + (currentWidth * sinTh)),
           bl  = new fabric.Point(tl.x - (currentHeight * sinTh), tl.y + (currentHeight * cosTh)),
@@ -335,7 +342,7 @@
          canvas.contextTop.fillRect(mtr.x, mtr.y, 3, 3);
        }, 50); */
 
-      this.oCoords = {
+      oCoords = {
         // corners
         tl: tl, tr: tr, br: br, bl: bl,
         // middle
@@ -344,10 +351,15 @@
         mtr: mtr
       };
 
-      // set coordinates of the draggable boxes in the corners used to scale/rotate the image
-      this._setCornerCoords && this._setCornerCoords();
+      if (normalized) {
+        this.oCoordsNormal = oCoords;
+      }
+      else {
+        this.oCoords = oCoords;
+      }
 
-      return this;
+      // set coordinates of the draggable boxes in the corners used to scale/rotate the image
+      this._setCornerCoords && this._setCornerCoords(normalized);
     },
 
     _calcRotateMatrix: function() {

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -29,6 +29,11 @@
           xPoints,
           lines;
       this.__corner = 0;
+
+      if (this.group) {
+        this.group.update();
+      }
+
       for (var i in this.oCoords) {
 
         if (!this.isControlVisible(i)) {

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -24,17 +24,35 @@
         return false;
       }
 
-      var ex = pointer.x,
-          ey = pointer.y,
-          xPoints,
-          lines;
+      var result;
       this.__corner = 0;
 
       if (this.group) {
         this.group.update();
       }
 
-      for (var i in this.oCoords) {
+      if (this.oCoordsNormal) {
+        result = this._findTargetCornerByCoords(pointer, this.oCoordsNormal);
+      }
+
+      if (!result) {
+        return this._findTargetCornerByCoords(pointer, this.oCoords);
+      }
+      else {
+        return result;
+      }
+    },
+
+    /**
+     * @private
+     */
+    _findTargetCornerByCoords: function(pointer, coords) {
+      var ex = pointer.x,
+          ey = pointer.y,
+          xPoints,
+          lines;
+
+      for (var i in coords) {
 
         if (!this.isControlVisible(i)) {
           continue;
@@ -49,7 +67,7 @@
           continue;
         }
 
-        lines = this._getImageLines(this.oCoords[i].corner);
+        lines = this._getImageLines(coords[i].corner);
 
         // debugging
 
@@ -71,6 +89,7 @@
           return i;
         }
       }
+
       return false;
     },
 
@@ -79,15 +98,21 @@
      * the image used to scale/rotate it.
      * @private
      */
-    _setCornerCoords: function() {
-      var coords = this.oCoords,
-          newTheta = degreesToRadians(45 - this.angle),
+    _setCornerCoords: function(normalized) {
+      var newTheta = degreesToRadians(45 - this.angle),
           /* Math.sqrt(2 * Math.pow(this.cornerSize, 2)) / 2, */
           /* 0.707106 stands for sqrt(2)/2 */
           cornerHypotenuse = this.cornerSize * 0.707106,
           cosHalfOffset = cornerHypotenuse * Math.cos(newTheta),
           sinHalfOffset = cornerHypotenuse * Math.sin(newTheta),
-          x, y;
+          x, y, coords;
+
+      if (normalized) {
+        coords = this.oCoordsNormal;
+      }
+      else {
+        coords = this.oCoords;
+      }
 
       for (var point in coords) {
         x = coords[point].x;

--- a/src/mixins/object_origin.mixin.js
+++ b/src/mixins/object_origin.mixin.js
@@ -71,8 +71,16 @@
      * Returns the real center coordinates of the object
      * @return {fabric.Point}
      */
-    getCenterPoint: function() {
-      var leftTop = new fabric.Point(this.left, this.top);
+    getCenterPoint: function(ignoreGroup) {
+      var leftTop;
+
+      if (ignoreGroup) {
+        leftTop = new fabric.Point(this.originalLeft, this.originalTop);
+      }
+      else {
+        leftTop = new fabric.Point(this.left, this.top);
+      }
+
       return this.translateToCenterPoint(leftTop, this.originX, this.originY);
     },
 

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -162,6 +162,16 @@
     },
 
     /**
+     * Recalculates group's dimension, position.
+     * @return {fabric.Group} thisArg
+     * @chainable
+     */
+    update: function() {
+      this.addWithUpdate();
+      return this;
+    },
+
+    /**
      * @private
      */
     _setObjectGroup: function(object) {
@@ -210,6 +220,9 @@
      */
     _setupStateOnObject: function(object) {
       this.canvas && this.canvas.stateful && object.setupState();
+      if (object._objects) {
+        object._setupStateOnObjects();
+      }
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -426,10 +426,39 @@
       return this;
     },
 
+    getOverflowBounds: function() {
+      var bounds = this._getBounds(),
+          largestControl = 0;
+
+      for (var i = 0; i < this._objects.length; i++) {
+        if (this._objects[i].rotatingPointOffset > largestControl) {
+          largestControl = this._objects[i].rotatingPointOffset;
+        }
+
+        if (this._objects[i].cornerSize > largestControl) {
+          largestControl = this._objects[i].cornerSize;
+        }
+      }
+
+      bounds.left -= largestControl;
+      bounds.top -= largestControl;
+      bounds.width += 2 * largestControl;
+      bounds.height += 2 * largestControl;
+
+      return bounds;
+    },
+
     /**
      * @private
      */
     _calcBounds: function(onlyWidthHeight) {
+      this.set(this._getBounds(onlyWidthHeight));
+    },
+
+    /**
+     * @private
+     */
+    _getObjectsBounds: function() {
       var aX = [],
           aY = [],
           o, prop,
@@ -447,14 +476,17 @@
         }
       }
 
-      this.set(this._getBounds(aX, aY, onlyWidthHeight));
+      return [aX, aY];
     },
 
     /**
      * @private
      */
-    _getBounds: function(aX, aY, onlyWidthHeight) {
+    _getBounds: function(onlyWidthHeight) {
       var ivt = fabric.util.invertTransform(this.getViewportTransform()),
+          aXY = this._getObjectsBounds(),
+          aX = aXY[0],
+          aY = aXY[1],
           minXY = fabric.util.transformPoint(new fabric.Point(min(aX), min(aY)), ivt),
           maxXY = fabric.util.transformPoint(new fabric.Point(max(aX), max(aY)), ivt),
           obj = {

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -147,10 +147,48 @@
      * @chainable
      */
     addWithUpdate: function(object) {
+      this._addWithUpdate(object);
+      return this;
+    },
+
+    /**
+     * Inserts an object into collection at specified index; Then recalculates group's dimension, position.
+     * @param {Object} object Object to insert
+     * @param {Number} index Index to insert object at
+     * @param {Boolean} nonSplicing When `true`, no splicing (shifting) of objects occurs
+     * @return {fabric.Group} thisArg
+     * @chainable
+     */
+    insertAtWithUpdate: function(object, index, nonSplicing) {
+      this._addWithUpdate(object, index, nonSplicing);
+      return this;
+    },
+
+    /*
+     * @private
+     */
+    _addWithUpdate: function(object, index, nonSplicing) {
+      if (this.group) {
+        var parentGroup = this.group,
+            index = parentGroup._objects.indexOf(this);
+
+        parentGroup.removeWithUpdate(this);
+      }
+
       this._restoreObjectsState();
       fabric.util.resetObjectTransform(this);
       if (object) {
-        this._objects.push(object);
+        if (typeof index == 'undefined') {
+          this._objects.push(object);
+        }
+        else {
+          if (nonSplicing) {
+            this._objects[index] = object;
+          }
+          else {
+            this._objects.splice(index, 0, object);
+          }
+        }
         object.group = this;
         object._set('canvas', this.canvas);
       }
@@ -158,7 +196,10 @@
       this.forEachObject(this._setObjectGroup, this);
       this._calcBounds();
       this._updateObjectsCoords();
-      return this;
+
+      if (parentGroup) {
+        parentGroup.insertAtWithUpdate(this, index);
+      }
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -136,8 +136,7 @@
      * @chainable
      */
     addWithUpdate: function(object) {
-      this._addWithUpdate(object);
-      return this;
+      return this.insertAtWithUpdate(object);
     },
 
     /**
@@ -149,14 +148,6 @@
      * @chainable
      */
     insertAtWithUpdate: function(object, index, nonSplicing) {
-      this._addWithUpdate(object, index, nonSplicing);
-      return this;
-    },
-
-    /*
-     * @private
-     */
-    _addWithUpdate: function(object, index, nonSplicing) {
       if (this.group) {
         var parentGroup = this.group,
             index = parentGroup._objects.indexOf(this);
@@ -189,6 +180,8 @@
       if (parentGroup) {
         parentGroup.insertAtWithUpdate(this, index);
       }
+
+      return this;
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -379,8 +379,6 @@
     _restoreObjectState: function(object) {
       this.realizeTransform(object);
       object.setCoords();
-      delete object.__origHasControls;
-      object.set('active', false);
       delete object.group;
 
       return this;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -115,10 +115,6 @@
      * @param {Boolean} [skipCoordsChange] if true, coordinates of object dose not change
      */
     _updateObjectCoords: function(object, skipCoordsChange) {
-      // do not display corners of objects enclosed in a group
-      object.__origHasControls = object.hasControls;
-      object.hasControls = false;
-
       if (skipCoordsChange) {
         return;
       }
@@ -158,8 +154,8 @@
         object.group = this;
         object._set('canvas', this.canvas);
       }
-      // since _restoreObjectsState set objects inactive
-      this.forEachObject(this._setObjectActive, this);
+      // since _restoreObjectsState obliterates group
+      this.forEachObject(this._setObjectGroup, this);
       this._calcBounds();
       this._updateObjectsCoords();
       return this;
@@ -168,8 +164,7 @@
     /**
      * @private
      */
-    _setObjectActive: function(object) {
-      object.set('active', true);
+    _setObjectGroup: function(object) {
       object.group = this;
     },
 
@@ -182,8 +177,8 @@
     removeWithUpdate: function(object) {
       this._restoreObjectsState();
       fabric.util.resetObjectTransform(this);
-      // since _restoreObjectsState set objects inactive
-      this.forEachObject(this._setObjectActive, this);
+      // since _restoreObjectsState obliterates group
+      this.forEachObject(this._setObjectGroup, this);
 
       this.remove(object);
       this._calcBounds();
@@ -371,7 +366,6 @@
     _restoreObjectState: function(object) {
       this.realizeTransform(object);
       object.setCoords();
-      object.hasControls = object.__origHasControls;
       delete object.__origHasControls;
       object.set('active', false);
       delete object.group;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -90,6 +90,11 @@
         this.callSuper('initialize', options);
       }
 
+      this.on('added', function() {
+        this._setupStateOnObjects();
+      });
+
+      this._setupStateOnObjects();
       this.setCoords();
       this.saveCoords();
     },
@@ -193,6 +198,23 @@
     _onObjectAdded: function(object) {
       object.group = this;
       object._set('canvas', this.canvas);
+      this._setupStateOnObject(object);
+    },
+
+    /**
+     * @private
+     */
+    _setupStateOnObjects: function() {
+      for (var i = 0; i < this._objects.length; i++) {
+        this._setupStateOnObject(this._objects[i]);
+      }
+    },
+
+    /**
+     * @private
+     */
+    _setupStateOnObject: function(object) {
+      this.canvas && this.canvas.stateful && object.setupState();
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -243,7 +243,7 @@
      */
     _setupStateOnObject: function(object) {
       this.canvas && this.canvas.stateful && object.setupState();
-      if (object._objects) {
+      if (object instanceof fabric.Group) {
         object._setupStateOnObjects();
       }
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -79,12 +79,7 @@
         this.originY = options.originY;
       }
 
-      if (isAlreadyGrouped) {
-        // do not change coordinate of objects enclosed in a group,
-        // because objects coordinate system have been group coodinate system already.
-        this._updateObjectsCoords(true);
-      }
-      else {
+      if (!isAlreadyGrouped) {
         this._calcBounds();
         this._updateObjectsCoords();
         this.callSuper('initialize', options);
@@ -101,24 +96,18 @@
 
     /**
      * @private
-     * @param {Boolean} [skipCoordsChange] if true, coordinates of objects enclosed in a group do not change
      */
-    _updateObjectsCoords: function(skipCoordsChange) {
+    _updateObjectsCoords: function() {
       for (var i = this._objects.length; i--; ){
-        this._updateObjectCoords(this._objects[i], skipCoordsChange);
+        this._updateObjectCoords(this._objects[i]);
       }
     },
 
     /**
      * @private
      * @param {Object} object
-     * @param {Boolean} [skipCoordsChange] if true, coordinates of object dose not change
      */
-    _updateObjectCoords: function(object, skipCoordsChange) {
-      if (skipCoordsChange) {
-        return;
-      }
-
+    _updateObjectCoords: function(object) {
       var objectLeft = object.getLeft(),
           objectTop = object.getTop(),
           center = this.getCenterPoint();

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -136,7 +136,7 @@
      * @chainable
      */
     addWithUpdate: function(object) {
-      return this.insertAtWithUpdate(object);
+      return this.insertWithUpdate(object);
     },
 
     /**
@@ -147,7 +147,7 @@
      * @return {fabric.Group} thisArg
      * @chainable
      */
-    insertAtWithUpdate: function(object, index, nonSplicing) {
+    insertWithUpdate: function(object, index, nonSplicing) {
       if (this.group) {
         var parentGroup = this.group,
             index = parentGroup._objects.indexOf(this);
@@ -178,7 +178,7 @@
       this._updateObjectsCoords();
 
       if (parentGroup) {
-        parentGroup.insertAtWithUpdate(this, index);
+        parentGroup.insertWithUpdate(this, index);
       }
 
       return this;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -426,28 +426,6 @@
       return this;
     },
 
-    getOverflowBounds: function() {
-      var bounds = this._getBounds(),
-          largestControl = 0;
-
-      for (var i = 0; i < this._objects.length; i++) {
-        if (this._objects[i].rotatingPointOffset > largestControl) {
-          largestControl = this._objects[i].rotatingPointOffset;
-        }
-
-        if (this._objects[i].cornerSize > largestControl) {
-          largestControl = this._objects[i].cornerSize;
-        }
-      }
-
-      bounds.left -= largestControl;
-      bounds.top -= largestControl;
-      bounds.width += 2 * largestControl;
-      bounds.height += 2 * largestControl;
-
-      return bounds;
-    },
-
     /**
      * @private
      */

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1156,8 +1156,7 @@
      * @param {Boolean} [noTransform] When true, context is not transformed
      */
     _renderControls: function(ctx, noTransform) {
-      if (!this.active || noTransform
-          || (this.group && this.group !== this.canvas.getActiveGroup())) {
+      if (!this.active || noTransform) {
         return;
       }
 
@@ -1172,7 +1171,7 @@
       ctx.lineWidth = 1 / this.borderScaleFactor;
       ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
 
-      if (this.group && this.group === this.canvas.getActiveGroup()) {
+      if (this.group) {
         ctx.rotate(degreesToRadians(options.angle));
         this.drawBordersInGroup(ctx, options);
       }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -935,6 +935,25 @@
     },
 
     /**
+     * Executes given function for each parent group all the way up
+     * @param {Function} callback
+     *                   Callback invoked with current group object as first argument.
+     *                   Callback is invoked in a context of Global Object (e.g. `window`)
+     *                   when no `context` argument is given
+     *
+     * @param {Object} context Context (aka thisObject)
+     * @return {Self} thisArg
+     */
+    bubbleThroughGroups: function(callback, context) {
+      var parentGroup = this.group;
+      while (parentGroup) {
+        callback.call(context, parentGroup);
+        parentGroup = parentGroup.group;
+      }
+      return this;
+    },
+
+    /**
      * Returns a string representation of an instance
      * @return {String}
      */

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1173,7 +1173,13 @@
 
       if (this.group) {
         ctx.rotate(degreesToRadians(options.angle));
-        this.drawBordersInGroup(ctx, options);
+
+        if (this.active) {
+          this.drawBorders(ctx, options);
+        }
+        else {
+          this.drawBordersInGroup(ctx, options);
+        }
       }
       else {
         ctx.rotate(degreesToRadians(this.angle));


### PR DESCRIPTION
This pull requests allows for objects inside of groups to be selected without ungrouping.

It is currently in a working state, but with some roadblocks and is not currently presumed fit for final review, but instead is currently more a request for comments.

Tests also still need to be written/updated.

It also branches off of the yet unmerged pull request #2997 (this is necessary due to that PR containing the groundwork for this functionality). I will rebase this branch once that PR is merged into master.

The UI used is very straightforward and workable with precedent from the application Sketch. It relies on double clicking. Double clicking drills down to the object that was double clicked on as well as making it so everything at that level of nesting and above can now be freely selected with single clicks. Leaving this click context (by selecting a different higher level element) resets the single click stuff. This is easier played with than reading about; try it out and use double clicking to select grouped and nested group objects.

@asturur I'm going to move all my #2997-off-topic questions here to stop cluttering your thread :)

# Shortcomings

There is one major shortcoming. The selection/active group setting of non-contiguous objects and objects already within permanent groups. It currently fails and bugs out for obvious reasons. I'm going to start work on this, however I'm still trying to think of the best route. Suggestions are welcome.

One question I have is is the point of `preserveObjectStacking`? It seems like it would always be desirable to have it set to true. Why would someone ever have it false? Having it false also makes the above shortcoming even more complicated.