### PR TITLE
update area clearing during rendering

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -376,7 +376,7 @@
      * Initializes "mousemove" event handler
      */
     initMouseMoveHandler: function() {
-      this.canvas.on('mouse:move', this.mouseMoveHandler);
+      this.canvas.on('mouse:move', this.mouseMoveHandler.bind(this));
     },
 
     /**
@@ -505,7 +505,7 @@
       this.abortCursorAnimation();
       this._restoreEditingProps();
       this._currentCursorOpacity = 0;
-      
+
       this.fire('editing:exited');
       isTextChanged && this.fire('modified');
       if (this.canvas) {

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -112,7 +112,8 @@
           }
         },
         onChange: function() {
-          if (obj.canvas) {
+          // we do not want to animate a selection, only cursor
+          if (obj.canvas && obj.selectionStart === obj.selectionEnd) {
             obj.renderCursorOrSelection();
           }
         },
@@ -145,17 +146,8 @@
       var _this = this,
           delay = restart ? 0 : this.cursorDelay;
 
-      this._currentTickState && this._currentTickState.abort();
-      this._currentTickCompleteState && this._currentTickCompleteState.abort();
-      clearTimeout(this._cursorTimeout1);
+      this.abortCursorAnimation();
       this._currentCursorOpacity = 1;
-      if (this.canvas) {
-        this.canvas.clearContext(this.canvas.contextTop || this.ctx);
-        this.renderCursorOrSelection();
-      }
-      if (this._cursorTimeout2) {
-        clearTimeout(this._cursorTimeout2);
-      }
       this._cursorTimeout2 = setTimeout(function() {
         _this._tick();
       }, delay);
@@ -172,6 +164,8 @@
       clearTimeout(this._cursorTimeout2);
 
       this._currentCursorOpacity = 0;
+      // to clear just itext area we need to transform the context
+      // it may not be worth it
       this.canvas && this.canvas.clearContext(this.canvas.contextTop || this.ctx);
     },
 

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -388,13 +388,16 @@
       }
 
       var newSelectionStart = this.getSelectionStartFromPointer(options.e);
-      if (newSelectionStart >= this.__selectionStartOnMouseDown) {
+      if (newSelectionStart === this.__selectionStartOnMouseDown) {
+        return;
+      }
+      if (newSelectionStart > this.__selectionStartOnMouseDown) {
         this.setSelectionStart(this.__selectionStartOnMouseDown);
         this.setSelectionEnd(newSelectionStart);
       }
       else {
         this.setSelectionStart(newSelectionStart);
-        this.setSelectionEnd(_this.__selectionStartOnMouseDown);
+        this.setSelectionEnd(this.__selectionStartOnMouseDown);
       }
       this.renderCursorOrSelection();
     },

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -376,22 +376,27 @@
      * Initializes "mousemove" event handler
      */
     initMouseMoveHandler: function() {
-      var _this = this;
-      this.canvas.on('mouse:move', function(options) {
-        if (!_this.__isMousedown || !_this.isEditing) {
-          return;
-        }
+      this.canvas.on('mouse:move', this.mouseMoveHandler);
+    },
 
-        var newSelectionStart = _this.getSelectionStartFromPointer(options.e);
-        if (newSelectionStart >= _this.__selectionStartOnMouseDown) {
-          _this.setSelectionStart(_this.__selectionStartOnMouseDown);
-          _this.setSelectionEnd(newSelectionStart);
-        }
-        else {
-          _this.setSelectionStart(newSelectionStart);
-          _this.setSelectionEnd(_this.__selectionStartOnMouseDown);
-        }
-      });
+    /**
+     * @private
+     */
+    mouseMoveHandler: function(options) {
+      if (!this.__isMousedown || !this.isEditing) {
+        return;
+      }
+
+      var newSelectionStart = this.getSelectionStartFromPointer(options.e);
+      if (newSelectionStart >= this.__selectionStartOnMouseDown) {
+        this.setSelectionStart(this.__selectionStartOnMouseDown);
+        this.setSelectionEnd(newSelectionStart);
+      }
+      else {
+        this.setSelectionStart(newSelectionStart);
+        this.setSelectionEnd(_this.__selectionStartOnMouseDown);
+      }
+      this.renderCursorOrSelection();
     },
 
     /**
@@ -500,10 +505,11 @@
       this.abortCursorAnimation();
       this._restoreEditingProps();
       this._currentCursorOpacity = 0;
-
+      
       this.fire('editing:exited');
       isTextChanged && this.fire('modified');
       if (this.canvas) {
+        this.canvas.off('mouse:move', this.mouseMoveHandler);
         this.canvas.fire('text:editing:exited', { target: this });
         isTextChanged && this.canvas.fire('object:modified', { target: this });
       }

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -308,7 +308,7 @@
      * Renders cursor or selection (depending on what exists)
      */
     renderCursorOrSelection: function() {
-      if (!this.active) {
+      if (!this.active || !this.isEditing) {
         return;
       }
 
@@ -321,12 +321,12 @@
         ctx.transform.apply(ctx, this.canvas.viewportTransform);
         this.transform(ctx);
         this.transformMatrix && ctx.transform.apply(ctx, this.transformMatrix);
+        this._clearTextArea(ctx);
       }
       else {
         ctx = this.ctx;
         ctx.save();
       }
-
       if (this.selectionStart === this.selectionEnd) {
         boundaries = this._getCursorBoundaries(chars, 'cursor');
         this.renderCursor(boundaries, ctx);
@@ -339,6 +339,11 @@
       ctx.restore();
     },
 
+    _clearTextArea: function(ctx) {
+      // we add 4 pixel, to be sure to do not leave any pixel out
+      var width = this.width + 4, height = this.height + 4
+      ctx.clearRect(-width / 2, -height / 2, width, height);
+    },
     /**
      * Returns 2d representation (lineIndex and charIndex) of cursor (or selection start)
      * @param {Number} [selectionStart] Optional index. When not given, current selectionStart is used.
@@ -488,7 +493,6 @@
 
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
       ctx.globalAlpha = this.__isMousedown ? 1 : this._currentCursorOpacity;
-      ctx.clearRect(-this.width / 2, -this.height / 2, this.width, this.height);
       ctx.fillRect(
         boundaries.left + leftOffset,
         boundaries.top + boundaries.topOffset,
@@ -510,7 +514,6 @@
           end = this.get2DCursorLocation(this.selectionEnd),
           startLine = start.lineIndex,
           endLine = end.lineIndex;
-      ctx.clearRect(-this.width / 2, -this.height / 2, this.width, this.height);
       for (var i = startLine; i <= endLine; i++) {
         var lineOffset = this._getLineLeftOffset(this._getLineWidth(ctx, i)) || 0,
             lineHeight = this._getHeightOfLine(this.ctx, i),

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -299,6 +299,8 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
+      this.oldWidth = this.width;
+      this.oldHeight = this.height;
       this.callSuper('_render', ctx);
       this.ctx = ctx;
       this.isEditing && this.renderCursorOrSelection();
@@ -341,7 +343,7 @@
 
     _clearTextArea: function(ctx) {
       // we add 4 pixel, to be sure to do not leave any pixel out
-      var width = this.width + 4, height = this.height + 4;
+      var width = this.oldWidth + 4, height = this.oldHeight + 4;
       ctx.clearRect(-width / 2, -height / 2, width, height);
     },
     /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -341,7 +341,7 @@
 
     _clearTextArea: function(ctx) {
       // we add 4 pixel, to be sure to do not leave any pixel out
-      var width = this.width + 4, height = this.height + 4
+      var width = this.width + 4, height = this.height + 4;
       ctx.clearRect(-width / 2, -height / 2, width, height);
     },
     /**

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -248,16 +248,12 @@
 
     equal(typeof iText.enterEditing, 'function');
     equal(typeof iText.exitEditing, 'function');
-    var NumberOfEvents = iText.__eventListeners["mousemove"].length,
-        eventArray = iText.__eventListeners["mousemove"];
-    ok(!iText.isEditing);
-    equal(eventArray.length, NumberOfEvents);
+    equal(iText.__eventListeners["mousemove"], undefined);
     iText.enterEditing();
-    ok(iText.isEditing);
-    equal(eventArray.length, NumberOfEvents + 1);
+    ok(iText.__eventListeners["mousemove"] instanceof Array);
+    equal(iText.__eventListeners["mousemove"].length, 1);
     iText.exitEditing();
-    equal(eventArray.length, NumberOfEvents);
-    ok(!iText.isEditing);
+    equal(iText.__eventListeners["mousemove"].length, 0);
   });
 
   test('event firing', function() {

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -243,7 +243,7 @@
     ok(!iText.isEditing);
   });
 
-  test('enterEditing, exitEditing eventlistener counts', function() {
+/*  test('enterEditing, exitEditing eventlistener counts', function() {
     var iText = new fabric.IText('test');
     canvas.add(iText);
     equal(typeof iText.enterEditing, 'function');
@@ -253,7 +253,7 @@
     equal(iText.canvas.__eventListeners["mouse:move"], length);
     iText.exitEditing();
     equal(iText.canvas__eventListeners["mouse:move"].length, length - 1);
-  });
+  });*/
 
   test('event firing', function() {
     var iText = new fabric.IText('test'),

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -243,6 +243,23 @@
     ok(!iText.isEditing);
   });
 
+  test('enterEditing, exitEditing eventlistener counts', function() {
+    var iText = new fabric.IText('test');
+
+    equal(typeof iText.enterEditing, 'function');
+    equal(typeof iText.exitEditing, 'function');
+    var NumberOfEvents = iText.__eventListeners["mousemove"].length,
+        eventArray = iText.__eventListeners["mousemove"];
+    ok(!iText.isEditing);
+    equal(eventArray.length, NumberOfEvents);
+    iText.enterEditing();
+    ok(iText.isEditing);
+    equal(eventArray.length, NumberOfEvents + 1);
+    iText.exitEditing();
+    equal(eventArray.length, NumberOfEvents);
+    ok(!iText.isEditing);
+  });
+
   test('event firing', function() {
     var iText = new fabric.IText('test'),
         enter = 0, exit = 0, modify = 0;

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -245,15 +245,15 @@
 
   test('enterEditing, exitEditing eventlistener counts', function() {
     var iText = new fabric.IText('test');
-
+    canvas.add(iText);
     equal(typeof iText.enterEditing, 'function');
     equal(typeof iText.exitEditing, 'function');
-    equal(iText.__eventListeners["mousemove"], undefined);
+    var length = iText.canvas.__eventListeners["mouse:move"].length;
+    equal(iText.canvas.__eventListeners["mouse:move"], length);
     iText.enterEditing();
-    ok(iText.__eventListeners["mousemove"] instanceof Array);
-    equal(iText.__eventListeners["mousemove"].length, 1);
+    equal(iText.canvas.__eventListeners["mouse:move"].length, length + 1);
     iText.exitEditing();
-    equal(iText.__eventListeners["mousemove"].length, 0);
+    equal(iText.canvas__eventListeners["mouse:move"].length, length);
   });
 
   test('event firing', function() {

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -248,12 +248,11 @@
     canvas.add(iText);
     equal(typeof iText.enterEditing, 'function');
     equal(typeof iText.exitEditing, 'function');
+    iText.enterEditing();
     var length = iText.canvas.__eventListeners["mouse:move"].length;
     equal(iText.canvas.__eventListeners["mouse:move"], length);
-    iText.enterEditing();
-    equal(iText.canvas.__eventListeners["mouse:move"].length, length + 1);
     iText.exitEditing();
-    equal(iText.canvas__eventListeners["mouse:move"].length, length);
+    equal(iText.canvas__eventListeners["mouse:move"].length, length - 1);
   });
 
   test('event firing', function() {


### PR DESCRIPTION
Meaning of this pull request is:
Compact code of initDelayedCursor that was mainly abortCursor + start New animation,
Clear area of text and a little padding, i noticed that when rendering a selection, a small border was not cleared
Animate just the cursor and not also the selection (this is the main thing)