### PR TITLE
Padding should not increase with canvas zooming

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -178,13 +178,9 @@
      */
     _calculateCurrentDimensions: function()  {
       var vpt = this.getViewportTransform(),
-          dim = this._getTransformedDimensions(),
-          w = dim.x, h = dim.y;
+          dim = this._getTransformedDimensions();
 
-      w += 2 * this.padding;
-      h += 2 * this.padding;
-
-      return fabric.util.transformPoint(new fabric.Point(w, h), vpt, true);
+      return fabric.util.transformPoint(dim, vpt, true).scalarAdd(2 * this.padding);
     },
 
     /**


### PR DESCRIPTION
I noticed that control padding increases with canvas zooming.
I think it should not.

I need some confirmation for merging this, and add some tests.
What do you think guys?

@kangax, @kienz, @inssein @DanieleSassoli  @sapics @alanmastro