### PR TITLE
Remove reference to lastRenderedWithControls when that object is deleted

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1361,6 +1361,17 @@
         this._objects[i]._renderControls(ctx);
         this.lastRenderedWithControls = this._objects[i];
       }
+    },
+
+    /**
+     * @private
+     * @param {fabric.Object} obj Object that was removed
+     */
+    _onObjectRemoved: function(obj) {
+      if (obj === this.lastRenderedWithControls) {
+        delete this.lastRenderedWithControls;
+      }
+      this.callSuper('_onObjectRemoved', obj);
     }
   });
 


### PR DESCRIPTION
This fixes an issue where a user could remove a textbox from the canvas, and then click in the space where the textbox was, and it would re-appear.