### PR TITLE
FindTarget patch 1

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -956,8 +956,8 @@
         return;
       }
 
-      var pointer = this.getPointer(e, true);
-      var activeGroup = this.getActiveGroup();
+      var pointer = this.getPointer(e, true),
+      activeGroup = this.getActiveGroup();
 
       // first check current group (if one exists)
       // active group does not check sub targets like normal groups.

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -955,7 +955,9 @@
       if (this.skipTargetFind) {
         return;
       }
-
+      
+      var pointer = this.getPointer(e, true);
+      
       // first check current group (if one exists)
       // avtive group does not check sub targets like normal groups.
       // if active group just exits.
@@ -964,8 +966,7 @@
         return activeGroup;
       }
 
-      var pointer = this.getPointer(e, true),
-          objects = this._objects;
+      var objects = this._objects;
       this.targets = [ ];
 
       if (this._isLastRenderedObject(pointer, e)) {

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -957,11 +957,11 @@
       }
 
       var pointer = this.getPointer(e, true);
+      var activeGroup = this.getActiveGroup();
 
       // first check current group (if one exists)
-      // avtive group does not check sub targets like normal groups.
+      // active group does not check sub targets like normal groups.
       // if active group just exits.
-      var activeGroup = this.getActiveGroup();
       if (activeGroup && !skipGroup && this._checkTarget(pointer, activeGroup)) {
         return activeGroup;
       }

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -955,9 +955,9 @@
       if (this.skipTargetFind) {
         return;
       }
-      
+
       var pointer = this.getPointer(e, true);
-      
+
       // first check current group (if one exists)
       // avtive group does not check sub targets like normal groups.
       // if active group just exits.


### PR DESCRIPTION
the activegroup was not working on transparency check because the pointer was not defined when calling findTarget on the activeGroup