### PR TITLE
Fix to Rect imported from svg is invisible when display = "none"

### DIFF
--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -222,7 +222,7 @@
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    rect.visible = rect.width > 0 && rect.height > 0;
+    rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     return rect;
   };
   /* _FROM_SVG_END_ */


### PR DESCRIPTION
i imported a svg file contain this line
`<rect x="12" y="0" display="none" width="56.7" height="56.7"/>`
display attriubute was 'none'.  but the rect was visible.
so i fixed it.