### PR TITLE
support style merging from css

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -931,7 +931,6 @@
         }
         rules = styleContents.match(/[^{]*\{[\s\S]*?\}/g);
         rules = rules.map(function(rule) { return rule.trim(); });
-
         rules.forEach(function(rule) {
 
           var match = rule.match(/([\s\S]*?)\s*\{([^}]*)\}/),
@@ -950,7 +949,12 @@
             if (_rule === '') {
               return;
             }
-            allRules[_rule] = fabric.util.object.clone(ruleObj);
+            if (allRules[_rule]) {
+              fabric.util.object.extend(allRules[_rule], ruleObj);
+            }
+            else {
+              allRules[_rule] = fabric.util.object.clone(ruleObj);
+            }
           });
         });
       }

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -559,4 +559,34 @@
     deepEqual(fabric.cssRules[svgUid], expectedStyle);
   });
 
+  test('getCssRule with same selectors', function() {
+
+    ok(fabric.getCSSRules);
+
+    var doc = fabric.document,
+        svgUid = 'uniqueId',
+        styleElement = doc.createElement('style');
+
+    styleElement.textContent = '.cls1,.cls2 { fill: #FF0000;} .cls1 { stroke: #00FF00;} .cls3,.cls1 { stroke-width: 3;}';
+
+    doc.body.appendChild(styleElement);
+
+    var expectedObject = {
+      '.cls1': {
+        'fill': '#FF0000',
+        'stroke': '#00FF00',
+        'strokeWidth': 3
+      },
+      '.cls2': {
+        'fill': '#FF0000'
+      },
+      '.cls3': {
+        'strokeWidth': 3
+      }
+    };
+
+    fabric.cssRules[svgUid] = fabric.getCSSRules(doc);
+    deepEqual(fabric.cssRules[svgUid], expectedObject);
+  });
+
 })();


### PR DESCRIPTION
before
```
.cls-1 {
  prop: value1;
}
.cls-1 {
  prop2: vlaue2;
}
```

was not merged correctly and just prop2 was taken.

Now is supported.

closes #3051