### PR TITLE
Add custom draw control functions

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -393,8 +393,8 @@
         case 'custom':
           if (this.drawCustomControlShape[control]) {
             this.drawCustomControlShape[control].call(this, ctx, left, top);
-            break;
           }
+          break;
         default:
           isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
           ctx[methodName + 'Rect'](left, top, size, size);

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -390,6 +390,11 @@
             ctx.stroke();
           }
           break;
+        case 'custom':
+          if (this.drawCustomControlShape[control]) {
+            this.drawCustomControlShape[control].call(this, ctx, left, top);
+            break;
+          }
         default:
           isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
           ctx[methodName + 'Rect'](left, top, size, size);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -471,6 +471,20 @@
     cornerStyle:          'rect',
 
     /**
+     * Draw custom control shapes, control in the corners and rotation-control.
+     * @since 1.6.4
+     * @type Object
+     * @example <caption>custom control shapes on all the corners</caption>
+     * drawCustomControlShape: {
+     *   bl: function(ctx: Object, left: number, top: number){},
+     *   br: function(ctx: Object, left: number, top: number){},
+     *   tl: function(ctx: Object, left: number, top: number){},
+     *   tr: function(ctx: Object, left: number, top: number){},
+     * }
+     */
+    drawCustomControlShape:   {},
+
+    /**
      * Array specifying dash pattern of an object's control (hasBorder must be true)
      * @since 1.6.2
      * @type Array


### PR DESCRIPTION
Add custom draw functions for the corner-resize-controls and rotation-control.

example in how to use:

```
canvas.on('object:selected', (event) => {
  const { target } = event;
  target.set({
    cornerStyle: 'custom',
    drawCustomControlShape: {
      bl: function drawCustomBorder(ctx, left, top, size) {
        // use ctx to draw corner shape for bl
      },
      br: function drawCustomBorder(ctx, left, top, size) {
        // use ctx to draw corner shape for br
      },
      tl: function drawCustomBorder(ctx, left, top, size) {
        // use ctx to draw corner shape for tl
      },
      tr: function drawCustomBorder(ctx, left, top, size) {
        // use ctx to draw corner shape for tr
      },
      mtr: function drawCustomBorder(ctx, left, top, size) {
        // use ctx to draw corner shape for mtr
      }
    }
  });
});
```
