### PR TITLE
IE replace text selection with keypress

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -93,10 +93,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.__mousedownY = pointer.y;
       this.__isMousedown = true;
 
-      if (this.hiddenTextarea && this.canvas) {
-        this.canvas.wrapperEl.appendChild(this.hiddenTextarea);
-      }
-
       if (this.selected) {
         this.setCursorByClick(options.e);
       }

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -9,12 +9,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     var style = this._calcTextareaPosition();
     this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + style.top + '; left: ' + style.left + ';'
                                         + ' opacity: 0; width: 0px; height: 0px; z-index: -999;';
-    if (this.canvas) {
-      this.canvas.lowerCanvasEl.parentNode.appendChild(this.hiddenTextarea);
-    }
-    else {
-      fabric.document.body.appendChild(this.hiddenTextarea);
-    }
+    fabric.document.body.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'keyup', this.onKeyUp.bind(this));


### PR DESCRIPTION
Why:

* After creating a textbox, selecting text, and pressing a key, the first character of the previous text would remain.
* This happened because the hidden textarea would not update its selection in IE when it was in the same parent element as the canvas.

This change addresses the need by:

* Keeping the hidden textarea in the body element.
* IE now correctly updates the text selection as the user interacts with the canvas textbox.

Behavior in IE 11 before this change:
![0417548e-55a6-11e6-84a3-e427f30b78fe](https://cloud.githubusercontent.com/assets/232863/17296317/99474166-57ce-11e6-86d6-c4750c633ac4.gif)

Behaviour in IE 11 after this change:
![1618c92e-55a6-11e6-94c4-a356685ceee3](https://cloud.githubusercontent.com/assets/232863/17296306/88c55918-57ce-11e6-9706-d47bb79d0804.gif)

closes #2451