### PR TITLE
Added missing object:added on docs

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -15,6 +15,7 @@
    * @tutorial {@link http://fabricjs.com/fabric-intro-part-1#canvas}
    * @see {@link fabric.Canvas#initialize} for constructor definition
    *
+   * @fires object:added
    * @fires object:modified
    * @fires object:rotating
    * @fires object:scaling


### PR DESCRIPTION
`object:added` is also fired by canvas. It is proved on the test cases: https://github.com/kangax/fabric.js/blob/1.6.3/test/unit/canvas_static.js#L269-L279