### PR TITLE
Change borderScaleFactor behaviour (#2930)

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1183,7 +1183,7 @@
 
       ctx.save();
       ctx.translate(options.translateX, options.translateY);
-      ctx.lineWidth = 1 / this.borderScaleFactor;
+      ctx.lineWidth = 1 * this.borderScaleFactor;
       ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
 
       if (this.group && this.group === this.canvas.getActiveGroup()) {


### PR DESCRIPTION
See discussion in https://github.com/kangax/fabric.js/issues/2930

I think a multiplication makes much more sense here to cover all use cases. My use case for example is to render a 2px border.