### PR TITLE
`getObjects` method sometimes returns a reference to its internal _objects  array and sometimes a copy

### DIFF
--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -93,7 +93,7 @@ fabric.Collection = {
    */
   getObjects: function(type) {
     if (typeof type === 'undefined') {
-      return this._objects;
+      return this._objects.slice(0);
     }
     return this._objects.filter(function(o) {
       return o.type === type;


### PR DESCRIPTION
I was working on a project recently where we wanted to get all the fabric objects, loop over them, and remove the ones we didn't need anymore.  Unfortunately the `getObjects` method returned us a reference to fabric's internal `_objects` array.  This meant that as we removed elements from the canvas, we also removed them from the list we were looping over.

I looked at the code for `getObjects` and noticed that fabric is sometimes returning a filtered copy of the elements, and sometimes the internal list.  This PR makes it consistently return a copy.  I understand if this isn't a useful / desired PR but just thought I would document and suggest a fix.

Thanks for all the hard work on fabric!