### PR TITLE
replaced 'or' with 'and' in order to enforce 'uniScaleTransform' flag

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -677,7 +677,7 @@
      * @return {Boolean} true if the scaling occurred
      */
     _onScale: function(e, transform, x, y) {
-      if ((e[this.uniScaleKey] || this.uniScaleTransform) && !transform.target.get('lockUniScaling')) {
+      if ((this.uniScaleTransform && e[this.uniScaleKey]) && !transform.target.get('lockUniScaling')) {
         transform.currentAction = 'scale';
         return this._scaleObject(x, y);
       }


### PR DESCRIPTION
1.6.2

The "uniScaleTransform" flag is not actually enforced if false (the default) because of an accidental "or" where an "and" should be

Issue here:
https://github.com/kangax/fabric.js/issues/3162