### PR TITLE
Update collection.mixin.js

### DIFF
--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -75,7 +75,6 @@ fabric.Collection = {
    * @param {Function} callback
    *                   Callback invoked with current object as first argument,
    *                   index - as second and an array of all objects - as third.
-   *                   Iteration happens in reverse order (for performance reasons).
    *                   Callback is invoked in a context of Global Object (e.g. `window`)
    *                   when no `context` argument is given
    *
@@ -84,9 +83,8 @@ fabric.Collection = {
    * @chainable
    */
   forEachObject: function(callback, context) {
-    var objects = this.getObjects(),
-        i = objects.length;
-    while (i--) {
+    var objects = this.getObjects();
+    for (var i = 0, len = objects.length; i < len; i++) {
       callback.call(context, objects[i], i, objects);
     }
     return this;

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -368,8 +368,8 @@ test('toObject without default values', function() {
       iteratedObjects.push(groupObject);
     });
 
-    equal(iteratedObjects[1], group.getObjects()[0]);
-    equal(iteratedObjects[0], group.getObjects()[1]);
+    equal(iteratedObjects[0], group.getObjects()[0], 'iteration give back objects in same order');
+    equal(iteratedObjects[1], group.getObjects()[1], 'iteration give back objects in same order');
   });
 
   asyncTest('fromObject', function() {


### PR DESCRIPTION
Iterate on correct order.
Performance gain from iterate in inverse order a generally small array, was not worth the confusion in mixing the stack order when doing something different.