### PR TITLE
Make object fire deselect event

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1285,7 +1285,8 @@
       if (this.getActiveObject() === obj) {
         this.fire('before:selection:cleared', { target: obj });
         this._discardActiveObject();
-        this.fire('selection:cleared');
+        this.fire('selection:cleared', { target: obj });
+        obj.fire('deselected');
       }
       this.callSuper('_onObjectRemoved', obj);
     },
@@ -1301,14 +1302,17 @@
     },
 
     /**
-     * Discards currently active object
+     * Discards currently active object and fire events
+     * @param {event} e
      * @return {fabric.Canvas} thisArg
      * @chainable
      */
     discardActiveObject: function (e) {
+      var activeObject = this._activeObject;
+      this.fire('before:selection:cleared', { target: activeObject, e: e });
       this._discardActiveObject();
-      this.renderAll();
       this.fire('selection:cleared', { e: e });
+      activeObject && activeObject.fire('deselected', { e: e });
       return this;
     },
 
@@ -1359,10 +1363,13 @@
     },
 
     /**
-     * Discards currently active group
+     * Discards currently active group and fire events
      * @return {fabric.Canvas} thisArg
+     * @chainable
      */
     discardActiveGroup: function (e) {
+      var g = this.getActiveGroup();
+      this.fire('before:selection:cleared', { e: e, target: g });
       this._discardActiveGroup();
       this.fire('selection:cleared', { e: e });
       return this;
@@ -1371,6 +1378,7 @@
     /**
      * Deactivates all objects on canvas, removing any active group or object
      * @return {fabric.Canvas} thisArg
+     * @chainable
      */
     deactivateAll: function () {
       var allObjects = this.getObjects(),
@@ -1387,15 +1395,18 @@
     /**
      * Deactivates all objects and dispatches appropriate events
      * @return {fabric.Canvas} thisArg
+     * @chainable
      */
     deactivateAllWithDispatch: function (e) {
-      var activeObject = this.getActiveGroup() || this.getActiveObject();
-      if (activeObject) {
-        this.fire('before:selection:cleared', { target: activeObject, e: e });
+      var activeObject = this.getActiveGroup();
+      var activeGroup = this.getActiveObject();
+      if (activeObject || activeGroup) {
+        this.fire('before:selection:cleared', { target: activeObject || activeGroup, e: e });
       }
       this.deactivateAll();
-      if (activeObject) {
-        this.fire('selection:cleared', { e: e });
+      if (activeObject|| activeGroup) {
+        this.fire('selection:cleared', { e: e, target: activeObject });
+        activeObject && activeObject.fire('deselected');
       }
       return this;
     },

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1398,13 +1398,13 @@
      * @chainable
      */
     deactivateAllWithDispatch: function (e) {
-      var activeObject = this.getActiveGroup();
-      var activeGroup = this.getActiveObject();
+      var activeGroup = this.getActiveGroup();
+      var activeObject = this.getActiveObject();
       if (activeObject || activeGroup) {
         this.fire('before:selection:cleared', { target: activeObject || activeGroup, e: e });
       }
       this.deactivateAll();
-      if (activeObject|| activeGroup) {
+      if (activeObject || activeGroup) {
         this.fire('selection:cleared', { e: e, target: activeObject });
         activeObject && activeObject.fire('deselected');
       }

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1398,8 +1398,8 @@
      * @chainable
      */
     deactivateAllWithDispatch: function (e) {
-      var activeGroup = this.getActiveGroup();
-      var activeObject = this.getActiveObject();
+      var activeGroup = this.getActiveGroup(),
+          activeObject = this.getActiveObject();
       if (activeObject || activeGroup) {
         this.fire('before:selection:cleared', { target: activeObject || activeGroup, e: e });
       }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -23,6 +23,7 @@
    * @fires removed
    *
    * @fires selected
+   * @fires deselected
    * @fires modified
    * @fires rotating
    * @fires scaling


### PR DESCRIPTION
There is no current way to make some action during object deselection that will intervene after the deactivating the activeObject/ activeGroup.
We have selection:cleared that had no reference to object deselected.
To be similar to other events we mirror the event on single object.