### PR TITLE
added fill for images

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -306,6 +306,7 @@
       markup.push('<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n');
       if (this.fill) {
         var origStroke = this.stroke;
+        var origShadow = this.shadow;
         this.stroke = null;
         markup.push(
           '<rect ',
@@ -314,7 +315,6 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
-        this.stroke = origStroke;
       }
       markup.push(
         '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
@@ -338,11 +338,11 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
-        this.fill = origFill;
       }
-
       markup.push('</g>\n');
-
+      origFill && (this.fill = origFill);
+      origStroke && (this.stroke = origStroke);
+      origShadow && (this.shadow = origShadow);
       return reviver ? reviver(markup.join('')) : markup.join('');
     },
     /* _TO_SVG_END_ */

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -72,6 +72,13 @@
     meetOrSlice: 'meet',
 
     /**
+     * Color of image fill
+     * @type String
+     * @default
+     */
+    fill: '',
+
+    /**
      * Width of a stroke.
      * For image quality a stroke multiple of 2 gives better results.
      * @type Number
@@ -202,7 +209,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _stroke: function(ctx) {
-      if (!this.stroke || this.strokeWidth === 0) {
+      if ((!this.stroke || this.strokeWidth === 0) && !this.fill) {
         return;
       }
       var w = this.width / 2, h = this.height / 2;
@@ -296,21 +303,32 @@
       if (this.alignX !== 'none' && this.alignY !== 'none') {
         preserveAspectRatio = 'x' + this.alignX + 'Y' + this.alignY + ' ' + this.meetOrSlice;
       }
-      markup.push(
-        '<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n',
-          '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
-            '" x="', x, '" y="', y,
+      markup.push('<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n');
+      if (this.fill) {
+        var origStroke = this.stroke;
+        this.stroke = null;
+        markup.push(
+          '<rect ',
+            'x="', x, '" y="', y,
+            '" width="', this.width, '" height="', this.height,
             '" style="', this.getSvgStyles(),
-            // we're essentially moving origin of transformation from top/left corner to the center of the shape
-            // by wrapping it in container <g> element with actual transformation, then offsetting object to the top/left
-            // so that object's center aligns with container's left/top
-            '" width="', this.width,
-            '" height="', this.height,
-            '" preserveAspectRatio="', preserveAspectRatio, '"',
-          '></image>\n'
+          '"/>\n'
+        );
+        this.stroke = origStroke;
+      }
+      markup.push(
+        '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
+          '" x="', x, '" y="', y,
+          '" style="', this.getSvgStyles(),
+          // we're essentially moving origin of transformation from top/left corner to the center of the shape
+          // by wrapping it in container <g> element with actual transformation, then offsetting object to the top/left
+          // so that object's center aligns with container's left/top
+          '" width="', this.width,
+          '" height="', this.height,
+          '" preserveAspectRatio="', preserveAspectRatio, '"',
+        '></image>\n'
       );
-
-      if (this.stroke || this.strokeDashArray) {
+      if (this.stroke) {
         var origFill = this.fill;
         this.fill = null;
         markup.push(
@@ -472,6 +490,12 @@
       else {
         elementToDraw = this._element;
       }
+      this._stroke(ctx);
+      this._renderFill(ctx);
+      if (this.fill) {
+        // if renderedFill remove shadow for image
+        this._removeShadow(ctx);
+      }
       elementToDraw && ctx.drawImage(elementToDraw,
                                      x + imageMargins.marginX,
                                      y + imageMargins.marginY,
@@ -479,7 +503,6 @@
                                      imageMargins.height
                                     );
 
-      this._stroke(ctx);
       this._renderStroke(ctx);
     },
 

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -315,6 +315,7 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
+        this.shadow = null;
       }
       markup.push(
         '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -62,7 +62,7 @@
     'top':                      0,
     'width':                    IMG_WIDTH, // node-canvas doesn't seem to allow setting width/height on image objects
     'height':                   IMG_HEIGHT, // or does it now?
-    'fill':                     'rgb(0,0,0)',
+    'fill':                     '',
     'stroke':                   null,
     'strokeWidth':              0,
     'strokeDashArray':          null,

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -22,7 +22,7 @@
     'top':                      0,
     'width':                    IMG_WIDTH, // node-canvas doesn't seem to allow setting width/height on image objects
     'height':                   IMG_HEIGHT, // or does it now?
-    'fill':                     'rgb(0,0,0)',
+    'fill':                     '',
     'stroke':                   null,
     'strokeWidth':              0,
     'strokeDashArray':          null,


### PR DESCRIPTION
Added standard fill properties to image ( gradient, patterns , color )

canvas:
![image](https://cloud.githubusercontent.com/assets/1194048/18610659/09bb7b38-7d22-11e6-8844-9155f5cb9de5.png)

output svg
![image](https://cloud.githubusercontent.com/assets/1194048/18610665/0fd79eac-7d22-11e6-9a5b-f6b898066ca5.png)

behaviour with shadows:
![image](https://cloud.githubusercontent.com/assets/1194048/18610721/b4f5fc52-7d23-11e6-8efd-c7e07e1c24a1.png)


```xml
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="700" height="600" viewBox="0 0 700 600" xml:space="preserve">
<desc>Created with Fabric.js 1.6.4</desc>
<defs></defs>
<linearGradient id="SVGID_1" gradientUnits="userSpaceOnUse" x1="-163.5" y1="-163.5" x2="163.5" y2="163.5">
<stop offset="0%" style="stop-color:rgb(175,236,217);stop-opacity: 1"/>
<stop offset="100%" style="stop-color:rgb(217,13,165);stop-opacity: 1"/>
</linearGradient>
<g transform="translate(388.5 335.5)">
<rect x="-163.5" y="-163.5" width="327" height="327" style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: url(#SVGID_1); fill-rule: nonzero; opacity: 1;"/>
<image xlink:href="https://upload.wikimedia.org/wikipedia/commons/1/16/Rainbow_trout_transparent.png" x="-163.5" y="-163.5" style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: url(#SVGID_1); fill-rule: nonzero; opacity: 1;" width="327" height="327" preserveAspectRatio="none"></image>
</g>
</svg>
```

close #2112