### PR TITLE
Fillforimages

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -355,6 +355,10 @@
       return this;
     },
 
+    /*
+     * calculate rotation matrix of an object
+     * @return {Array} rotation matrix for the object
+     */
     _calcRotateMatrix: function() {
       if (this.angle) {
         var theta = degreesToRadians(this.angle), cos = Math.cos(theta), sin = Math.sin(theta);

--- a/src/mixins/stateful.mixin.js
+++ b/src/mixins/stateful.mixin.js
@@ -1,45 +1,75 @@
-/*
-  Depends on `stateProperties`
-*/
-fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prototype */ {
+(function() {
 
-  /**
-   * Returns true if object state (one of its state properties) was changed
-   * @return {Boolean} true if instance' state has changed since `{@link fabric.Object#saveState}` was called
-   */
-  hasStateChanged: function() {
-    return this.stateProperties.some(function(prop) {
-      return this.get(prop) !== this.originalState[prop];
-    }, this);
-  },
+  var extend = fabric.util.object.extend;
 
-  /**
-   * Saves state of an object
-   * @param {Object} [options] Object with additional `stateProperties` array to include when saving state
-   * @return {fabric.Object} thisArg
-   */
-  saveState: function(options) {
-    this.stateProperties.forEach(function(prop) {
-      this.originalState[prop] = this.get(prop);
-    }, this);
-
-    if (options && options.stateProperties) {
-      options.stateProperties.forEach(function(prop) {
-        this.originalState[prop] = this.get(prop);
-      }, this);
-    }
-
-    return this;
-  },
-
-  /**
-   * Setups state of an object
-   * @return {fabric.Object} thisArg
-   */
-  setupState: function() {
-    this.originalState = { };
-    this.saveState();
-
-    return this;
+  /*
+    Depends on `stateProperties`
+  */
+  function saveProps(origin, destination, props) {
+    var tmpObj = { }, deep = true;
+    props.forEach(function(prop) {
+      tmpObj[prop] = origin[prop];
+    });
+    extend(origin[destination], tmpObj, deep);
   }
-});
+
+  function _isEqual(origValue, currentValue) {
+    if (origValue instanceof Array) {
+      if (origValue.length !== currentValue.length) {
+        return false
+      }
+      var _currentValue = currentValue.concat().sort(),
+          _origValue = origValue.concat().sort();
+      return !_origValue.some(function(v, i) {
+        return !_isEqual(_currentValue[i], v);
+      });
+    }
+    else if (origValue instanceof Object) {
+      for (var key in origValue) {
+        if (!_isEqual(origValue[key], currentValue[key])) {
+          return false;
+        }
+      }
+      return true;
+    }
+    else {
+      return origValue === currentValue;
+    }
+  }
+
+
+  fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prototype */ {
+
+    /**
+     * Returns true if object state (one of its state properties) was changed
+     * @return {Boolean} true if instance' state has changed since `{@link fabric.Object#saveState}` was called
+     */
+    hasStateChanged: function() {
+      return !_isEqual(this.originalState, this);
+    },
+
+    /**
+     * Saves state of an object
+     * @param {Object} [options] Object with additional `stateProperties` array to include when saving state
+     * @return {fabric.Object} thisArg
+     */
+    saveState: function(options) {
+      saveProps(this, 'originalState', this.stateProperties);
+      if (options && options.stateProperties) {
+        saveProps(this, 'originalState', options.stateProperties);
+      }
+      return this;
+    },
+
+    /**
+     * Setups state of an object
+     * @param {Object} [options] Object with additional `stateProperties` array to include when saving state
+     * @return {fabric.Object} thisArg
+     */
+    setupState: function(options) {
+      this.originalState = { };
+      this.saveState(options);
+      return this;
+    }
+  });
+})();

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -306,6 +306,7 @@
       markup.push('<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n');
       if (this.fill) {
         var origStroke = this.stroke;
+        var origShadow = this.shadow;
         this.stroke = null;
         markup.push(
           '<rect ',
@@ -314,7 +315,6 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
-        this.stroke = origStroke;
       }
       markup.push(
         '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
@@ -338,11 +338,11 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
-        this.fill = origFill;
       }
-
       markup.push('</g>\n');
-
+      origFill && (this.fill = origFill);
+      origStroke && (this.stroke = origStroke);
+      origShadow && (this.shadow = origShadow);
       return reviver ? reviver(markup.join('')) : markup.join('');
     },
     /* _TO_SVG_END_ */

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -72,6 +72,13 @@
     meetOrSlice: 'meet',
 
     /**
+     * Color of image fill
+     * @type String
+     * @default
+     */
+    fill: '',
+
+    /**
      * Width of a stroke.
      * For image quality a stroke multiple of 2 gives better results.
      * @type Number
@@ -202,7 +209,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _stroke: function(ctx) {
-      if (!this.stroke || this.strokeWidth === 0) {
+      if ((!this.stroke || this.strokeWidth === 0) && !this.fill) {
         return;
       }
       var w = this.width / 2, h = this.height / 2;
@@ -296,21 +303,32 @@
       if (this.alignX !== 'none' && this.alignY !== 'none') {
         preserveAspectRatio = 'x' + this.alignX + 'Y' + this.alignY + ' ' + this.meetOrSlice;
       }
-      markup.push(
-        '<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n',
-          '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
-            '" x="', x, '" y="', y,
+      markup.push('<g transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '">\n');
+      if (this.fill) {
+        var origStroke = this.stroke;
+        this.stroke = null;
+        markup.push(
+          '<rect ',
+            'x="', x, '" y="', y,
+            '" width="', this.width, '" height="', this.height,
             '" style="', this.getSvgStyles(),
-            // we're essentially moving origin of transformation from top/left corner to the center of the shape
-            // by wrapping it in container <g> element with actual transformation, then offsetting object to the top/left
-            // so that object's center aligns with container's left/top
-            '" width="', this.width,
-            '" height="', this.height,
-            '" preserveAspectRatio="', preserveAspectRatio, '"',
-          '></image>\n'
+          '"/>\n'
+        );
+        this.stroke = origStroke;
+      }
+      markup.push(
+        '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),
+          '" x="', x, '" y="', y,
+          '" style="', this.getSvgStyles(),
+          // we're essentially moving origin of transformation from top/left corner to the center of the shape
+          // by wrapping it in container <g> element with actual transformation, then offsetting object to the top/left
+          // so that object's center aligns with container's left/top
+          '" width="', this.width,
+          '" height="', this.height,
+          '" preserveAspectRatio="', preserveAspectRatio, '"',
+        '></image>\n'
       );
-
-      if (this.stroke || this.strokeDashArray) {
+      if (this.stroke) {
         var origFill = this.fill;
         this.fill = null;
         markup.push(
@@ -472,6 +490,12 @@
       else {
         elementToDraw = this._element;
       }
+      this._stroke(ctx);
+      this._renderFill(ctx);
+      if (this.fill) {
+        // if renderedFill remove shadow for image
+        this._removeShadow(ctx);
+      }
       elementToDraw && ctx.drawImage(elementToDraw,
                                      x + imageMargins.marginX,
                                      y + imageMargins.marginY,
@@ -479,7 +503,6 @@
                                      imageMargins.height
                                     );
 
-      this._stroke(ctx);
       this._renderStroke(ctx);
     },
 

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -13,6 +13,13 @@
     return;
   }
 
+  var stateProperties = fabric.Object.prototype.stateProperties.concat();
+  stateProperties.push(
+    'alignX',
+    'alignY',
+    'meetOrSlice'
+  );
+
   /**
    * Image class
    * @class fabric.Image
@@ -96,6 +103,14 @@
      * @type Number
      */
     minimumScaleTrigger: 0.5,
+
+    /**
+     * List of properties to consider when checking if
+     * state of an object is changed ({@link fabric.Object#hasStateChanged})
+     * as well as for history (undo/redo) purposes
+     * @type Array
+     */
+    stateProperties: stateProperties,
 
     /**
      * Constructor

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -315,6 +315,7 @@
             '" style="', this.getSvgStyles(),
           '"/>\n'
         );
+        this.shadow = null;
       }
       markup.push(
         '<image ', this.getSvgId(), 'xlink:href="', this.getSvgSrc(),

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -765,7 +765,7 @@
       'top left width height scaleX scaleY flipX flipY originX originY transformMatrix ' +
       'stroke strokeWidth strokeDashArray strokeLineCap strokeLineJoin strokeMiterLimit ' +
       'angle opacity fill fillRule globalCompositeOperation shadow clipTo visible backgroundColor ' +
-      'alignX alignY meetOrSlice skewX skewY'
+      'skewX skewY'
     ).split(' '),
 
     /**

--- a/src/util/lang_object.js
+++ b/src/util/lang_object.js
@@ -7,10 +7,30 @@
    * @param {Object} source Where to copy from
    * @return {Object}
    */
-  function extend(destination, source) {
+  function extend(destination, source, deep) {
     // JScript DontEnum bug is not taken care of
-    for (var property in source) {
-      destination[property] = source[property];
+    // the deep clone is for internal use, is not meant to avoid
+    // javascript traps or cloning html element or self referenced objects.
+    if (deep) {
+      if (source instanceof Array) {
+        destination = source.map(function(v) {
+          return clone(v, deep)
+        })
+      }
+      else if (source instanceof Object) {
+        for (var property in source) {
+          destination[property] = clone(source[property], deep)
+        }
+      }
+      else {
+        // this sounds odd for an extend but is ok for recursive use
+        destination = source;
+      }
+    }
+    else {
+      for (var property in source) {
+        destination[property] = source[property];
+      }
     }
     return destination;
   }
@@ -21,8 +41,8 @@
    * @param {Object} object Object to clone
    * @return {Object}
    */
-  function clone(object) {
-    return extend({ }, object);
+  function clone(object, deep) {
+    return extend({ }, object, deep);
   }
 
   /** @namespace fabric.util.object */

--- a/test.js
+++ b/test.js
@@ -41,6 +41,7 @@ testrunner.run({
       './test/unit/collection.js',
       './test/unit/point.js',
       './test/unit/intersection.js',
+      './test/unit/stateful.js'
     ]
 }, function(err, report) {
   if (err) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -346,17 +346,23 @@
   test('findTarget preserveObjectStacking true', function() {
     ok(typeof canvas.findTarget == 'function');
     canvas.preserveObjectStacking = true;
-    var rect = makeRect({ left: 0, top: 0 }),
-        rectOver = makeRect({ left: 0, top: 0 }),
+    var rect = makeRect({ left: 0, top: 0, width: 30, height: 30 }),
+        rectOver = makeRect({ left: 0, top: 0, width: 30, height: 30 }),
         target,
-        pointer = { clientX: 5, clientY: 5 };
+        pointer = { clientX: 15, clientY: 15, 'shiftKey': true },
+        pointer2 = { clientX: 4, clientY: 4 };
     canvas.add(rect);
     canvas.add(rectOver);
     target = canvas.findTarget(pointer);
     equal(target, rectOver, 'Should return the rectOver, rect is not considered');
     canvas.setActiveObject(rect);
     target = canvas.findTarget(pointer);
-    equal(target, rect, 'Should return the rect, because it is active');
+    equal(target, rectOver, 'Should still return rectOver because is above active object');
+    target = canvas.findTarget(pointer2);
+    equal(target, rect, 'Should rect because a corner of the activeObject has been hit');
+    canvas.altSelectionKey = 'shiftKey';
+    target = canvas.findTarget(pointer);
+    equal(target, rect, 'Should rect because active and altSelectionKey is pressed');
     canvas.preserveObjectStacking = false;
   });
 

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -62,7 +62,7 @@
     'top':                      0,
     'width':                    IMG_WIDTH, // node-canvas doesn't seem to allow setting width/height on image objects
     'height':                   IMG_HEIGHT, // or does it now?
-    'fill':                     'rgb(0,0,0)',
+    'fill':                     '',
     'stroke':                   null,
     'strokeWidth':              0,
     'strokeDashArray':          null,

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -22,7 +22,7 @@
     'top':                      0,
     'width':                    IMG_WIDTH, // node-canvas doesn't seem to allow setting width/height on image objects
     'height':                   IMG_HEIGHT, // or does it now?
-    'fill':                     'rgb(0,0,0)',
+    'fill':                     '',
     'stroke':                   null,
     'strokeWidth':              0,
     'strokeDashArray':          null,

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -680,28 +680,6 @@
     }
   });
 
-  test('hasStateChanged', function() {
-    var cObj = new fabric.Object();
-    ok(typeof cObj.hasStateChanged == 'function');
-    cObj.setupState();
-    ok(!cObj.hasStateChanged());
-    cObj.saveState();
-    cObj.set('left', 123).set('top', 456);
-    ok(cObj.hasStateChanged());
-  });
-
-  test('saveState', function() {
-    var cObj = new fabric.Object();
-    ok(typeof cObj.saveState == 'function');
-    cObj.setupState();
-    equal(cObj.saveState(), cObj, 'chainable');
-    cObj.set('left', 123).set('top', 456);
-    cObj.saveState();
-    cObj.set('left', 223).set('top', 556);
-    equal(cObj.originalState.left, 123);
-    equal(cObj.originalState.top, 456);
-  });
-
   test('intersectsWithRectangle', function() {
     var cObj = new fabric.Object({ left: 50, top: 50, width: 100, height: 100 });
     cObj.setCoords();

--- a/test/unit/stateful.js
+++ b/test/unit/stateful.js
@@ -1,0 +1,98 @@
+(function(){
+
+  QUnit.module('fabric.stateful');
+
+  test('hasStateChanged', function() {
+    var cObj = new fabric.Object();
+    ok(typeof cObj.hasStateChanged == 'function');
+    cObj.setupState();
+    ok(!cObj.hasStateChanged(), 'state should not be changed');
+    cObj.saveState();
+    cObj.set('left', 123).set('top', 456);
+    ok(cObj.hasStateChanged());
+  });
+
+  test('saveState', function() {
+    var cObj = new fabric.Object();
+    ok(typeof cObj.saveState == 'function');
+    cObj.setupState();
+    equal(cObj.saveState(), cObj, 'chainable');
+    cObj.set('left', 123).set('top', 456);
+    cObj.saveState();
+    cObj.set('left', 223).set('top', 556);
+    equal(cObj.originalState.left, 123);
+    equal(cObj.originalState.top, 456);
+  });
+
+  test('saveState with extra props', function() {
+    var cObj = new fabric.Object();
+    cObj.prop1 = 'a';
+    cObj.prop2 = 'b';
+    cObj.left = 123;
+    var extraProps = ['prop1', 'prop2'];
+    var options = { stateProperties: extraProps };
+    cObj.setupState(options);
+    equal(cObj.originalState.prop1, 'a', 'it saves the extra props');
+    equal(cObj.originalState.prop2, 'b', 'it saves the extra props');
+    cObj.prop1 = 'c';
+    ok(cObj.hasStateChanged(), 'it detects changes in extra props');
+    equal(cObj.originalState.left, 123, 'normal props are still there');
+  });
+
+  test('saveState with array', function() {
+    var cObj = new fabric.Text('Hello');
+    cObj.set('textDecoration', ['underline']);
+    cObj.setupState();
+    deepEqual(cObj.textDecoration, cObj.originalState.textDecoration, 'textDecoration in state is deepEqual');
+    notEqual(cObj.textDecoration, cObj.originalState.textDecoration, 'textDecoration in not same Object');
+    cObj.textDecoration[0] = 'overline';
+    ok(cObj.hasStateChanged(), 'hasStateChanged detects changes in nested props');
+
+    cObj.set('textDecoration', ['overline', 'underline']);
+    cObj.saveState();
+    cObj.set('textDecoration', ['underline', 'overline']);
+    ok(!cObj.hasStateChanged(), 'order does no matter');
+
+    cObj.set('textDecoration', ['underline']);
+    cObj.saveState();
+    cObj.set('textDecoration', ['underline', 'overline']);
+    ok(cObj.hasStateChanged(), 'more properties added');
+
+    cObj.set('textDecoration', ['underline', 'overline']);
+    cObj.saveState();
+    cObj.set('textDecoration', ['overline']);
+    ok(cObj.hasStateChanged(), 'less properties');
+  });
+
+  test('saveState with fabric class gradient', function() {
+    var cObj = new fabric.Object();
+    var gradient = new fabric.Gradient({
+      type: 'linear',
+      coords: {
+        x1: 0,
+        y1: 10,
+        x2: 100,
+        y2: 200,
+      },
+      colorStops: [
+        { offset: 0, color: 'red', opacity: 0 },
+        { offset: 1, color: 'green' }
+      ]
+    });
+
+    cObj.set('fill', '#FF0000');
+    cObj.setupState();
+    cObj.setFill(gradient);
+    ok(cObj.hasStateChanged(), 'hasStateChanged detects changes in nested props');
+    cObj.saveState();
+    gradient.type = 'radial';
+    ok(cObj.hasStateChanged(), 'hasStateChanged detects changes in nested props on first level of nesting');
+    cObj.saveState();
+    gradient.coords.x1 = 3;
+    ok(cObj.hasStateChanged(), 'hasStateChanged detects changes in nested props on second level of nesting');
+    cObj.saveState();
+    gradient.colorStops[0].color = 'blue';
+    ok(cObj.hasStateChanged(), 'hasStateChanged detects changes in nested props on third level of nesting');
+  });
+
+})();


### PR DESCRIPTION
Added standard fill properties to image ( gradient, patterns , color )

canvas:
![image](https://cloud.githubusercontent.com/assets/1194048/18610659/09bb7b38-7d22-11e6-8844-9155f5cb9de5.png)

output svg
![image](https://cloud.githubusercontent.com/assets/1194048/18610665/0fd79eac-7d22-11e6-9a5b-f6b898066ca5.png)

behaviour with shadows:
![image](https://cloud.githubusercontent.com/assets/1194048/18610721/b4f5fc52-7d23-11e6-8efd-c7e07e1c24a1.png)


```xml
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="700" height="600" viewBox="0 0 700 600" xml:space="preserve">
<desc>Created with Fabric.js 1.6.4</desc>
<defs></defs>
<linearGradient id="SVGID_1" gradientUnits="userSpaceOnUse" x1="-163.5" y1="-163.5" x2="163.5" y2="163.5">
<stop offset="0%" style="stop-color:rgb(175,236,217);stop-opacity: 1"/>
<stop offset="100%" style="stop-color:rgb(217,13,165);stop-opacity: 1"/>
</linearGradient>
<g transform="translate(388.5 335.5)">
<rect x="-163.5" y="-163.5" width="327" height="327" style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: url(#SVGID_1); fill-rule: nonzero; opacity: 1;"/>
<image xlink:href="https://upload.wikimedia.org/wikipedia/commons/1/16/Rainbow_trout_transparent.png" x="-163.5" y="-163.5" style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: url(#SVGID_1); fill-rule: nonzero; opacity: 1;" width="327" height="327" preserveAspectRatio="none"></image>
</g>
</svg>
```

close #2112