### PR TITLE
change how itext handle removal handlers

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -33,18 +33,14 @@
     initAddedHandler: function() {
       var _this = this;
       this.on('added', function() {
-        if (this.canvas && !this.canvas._hasITextHandlers) {
-          this.canvas._hasITextHandlers = true;
-          this._initCanvasHandlers();
-        }
-
-        // Track IText instances per-canvas. Only register in this array once added
-        // to a canvas; we don't want to leak a reference to the instance forever
-        // simply because it existed at some point.
-        // (Might be added to a collection, but not on a canvas.)
-        if (_this.canvas) {
-          _this.canvas._iTextInstances = _this.canvas._iTextInstances || [];
-          _this.canvas._iTextInstances.push(_this);
+        var canvas = _this.canvas;
+        if (canvas) {
+          if (!canvas._hasITextHandlers) {
+            canvas._hasITextHandlers = true;
+            _this._initCanvasHandlers(canvas);
+          }
+          canvas._iTextInstances = canvas._iTextInstances || [];
+          canvas._iTextInstances.push(_this);
         }
       });
     },
@@ -52,35 +48,46 @@
     initRemovedHandler: function() {
       var _this = this;
       this.on('removed', function() {
-        // (Might be removed from a collection, but not on a canvas.)
-        if (_this.canvas) {
-          _this.canvas._iTextInstances = _this.canvas._iTextInstances || [];
-          fabric.util.removeFromArray(_this.canvas._iTextInstances, _this);
+        var canvas = _this.canvas;
+        if (canvas) {
+          canvas._iTextInstances = canvas._iTextInstances || [];
+          fabric.util.removeFromArray(canvas._iTextInstances, _this);
+          if (canvas._iTextInstances.length === 0) {
+            canvas._hasITextHandlers = false;
+            _this._removeCanvasHandlers(canvas);
+          }
         }
       });
     },
 
     /**
+     * register canvas event to manage exiting on other instances
      * @private
      */
-    _initCanvasHandlers: function() {
-      var _this = this;
-
-      this.canvas.on('selection:cleared', function() {
-        fabric.IText.prototype.exitEditingOnOthers(_this.canvas);
-      });
-
-      this.canvas.on('mouse:up', function() {
-        if (_this.canvas._iTextInstances) {
-          _this.canvas._iTextInstances.forEach(function(obj) {
+    _initCanvasHandlers: function(canvas) {
+      canvas._canvasITextSelectionClearedHanlder = (function() {
+        fabric.IText.prototype.exitEditingOnOthers(canvas);
+      }).bind(this);
+      canvas._mouseUpITextHandler = (function() {
+        if (canvas._iTextInstances) {
+          canvas._iTextInstances.forEach(function(obj) {
             obj.__isMousedown = false;
           });
         }
-      });
+      }).bind(this);
+      canvas.on('selection:cleared', canvas._canvasSelectionClearedHanlder);
+      canvas.on('object:selected', canvas._canvasSelectionClearedHanlder);
+      canvas.on('mouse:up', canvas._mouseUpHandler);
+    },
 
-      this.canvas.on('object:selected', function() {
-        fabric.IText.prototype.exitEditingOnOthers(_this.canvas);
-      });
+    /**
+     * remove canvas event to manage exiting on other instances
+     * @private
+     */
+    _removeCanvasHandlers: function(canvas) {
+      canvas.off('selection:cleared', canvas._canvasSelectionClearedHanlder);
+      canvas.off('object:selected', canvas._canvasSelectionClearedHanlder);
+      canvas.off('mouse:up', canvas._mouseUpHandler);
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -784,6 +784,13 @@
       this.overlayImage = null;
       this.backgroundColor = '';
       this.overlayColor = ''
+      if (this._hasITextHandlers) {
+        this.off('selection:cleared', this._canvasSelectionClearedHanlder);
+        this.off('object:selected', this._canvasSelectionClearedHanlder);
+        this.off('mouse:up', this._mouseUpHandler);
+        this._iTextInstances = null;
+        this._hasITextHandlers = false;
+      }
       this.clearContext(this.contextContainer);
       this.fire('canvas:cleared');
       this.renderAll();

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -700,8 +700,8 @@
   test('object removal from canvas', function() {
     canvas.clear();
     canvas._iTextInstances = null;
-    var text1 = new fabric.IText("Text Will be here");
-    var text2 = new fabric.IText("Text Will be here");
+    var text1 = new fabric.IText('Text Will be here');
+    var text2 = new fabric.IText('Text Will be here');
     ok(!canvas._iTextInstances, 'canvas has no iText instances');
     ok(!canvas._hasITextHandlers, 'canvas has no handlers');
 

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -697,6 +697,34 @@
     equal(iText.getCurrentCharFontSize(1, 0), 40);
   });
 
+  test('object removal from canvas', function() {
+    canvas.clear();
+    canvas._iTextInstances = null;
+    var text1 = new fabric.IText("Text Will be here");
+    var text2 = new fabric.IText("Text Will be here");
+    ok(!canvas._iTextInstances, 'canvas has no iText instances');
+    ok(!canvas._hasITextHandlers, 'canvas has no handlers');
+
+    canvas.add(text1);
+    deepEqual(canvas._iTextInstances, [text1], 'canvas has 1 text instance');
+    ok(canvas._hasITextHandlers, 'canvas has handlers');
+    equal(canvas._iTextInstances.length, 1, 'just one itext object should be on canvas');
+
+    canvas.add(text2);
+    deepEqual(canvas._iTextInstances, [text1, text2], 'canvas has 2 text instance');
+    ok(canvas._hasITextHandlers, 'canvas has handlers');
+    equal(canvas._iTextInstances.length, 2, 'just two itext object should be on canvas');
+
+    canvas.remove(text1);
+    deepEqual(canvas._iTextInstances, [text2], 'canvas has 1 text instance');
+    ok(canvas._hasITextHandlers, 'canvas has handlers');
+    equal(canvas._iTextInstances.length, 1, 'just two itext object should be on canvas');
+
+    canvas.remove(text2);
+    deepEqual(canvas._iTextInstances, [], 'canvas has 0 text instance');
+    ok(!canvas._hasITextHandlers, 'canvas has no handlers');
+  });
+
   test('getCurrentCharColor', function() {
     var iText = new fabric.IText('test foo bar-baz\nqux', {
       styles: {


### PR DESCRIPTION
close #3320 

Make the handlers for adding and removing itext instances unique to the canvas so that they can be removed when there are no more itext instances

Properly remove canvas reference to the itext object when removed from canvas

Added same logic to canvas clear that was missing