### PR TITLE
FIX for toDataURL cropping

### DIFF
--- a/src/mixins/canvas_dataurl_exporter.mixin.js
+++ b/src/mixins/canvas_dataurl_exporter.mixin.js
@@ -58,7 +58,7 @@
       var origWidth = this.getWidth(),
           origHeight = this.getHeight(),
           scaledWidth = (cropping.width || this.getWidth()) * multiplier,
-          scaledHeight = (cropping.width || this.getHeight()) * multiplier,
+          scaledHeight = (cropping.height || this.getHeight()) * multiplier,
           zoom = this.getZoom(),
           newZoom = zoom * multiplier,
           vp = this.viewportTransform,

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -486,6 +486,23 @@
     }
   });
 
+  test('toDataURL cropping', function() {
+    ok(typeof canvas.toDataURL == 'function');
+    if (!fabric.Canvas.supports('toDataURL')) {
+      window.alert('toDataURL is not supported by this environment. Some of the tests can not be run.');
+    }
+    else {
+      var croppingWidth = 75,
+          croppingHeight = 50,
+          dataURL = canvas.toDataURL({width: croppingWidth, height: croppingHeight});
+
+      fabric.Image.fromURL(dataURL, function (img) {
+        equal(img.width, croppingWidth, 'Width of exported image should correspond to cropping width');
+        equal(img.height, croppingHeight, 'Height of exported image should correspond to cropping height');
+      });
+    }
+  });
+
   test('centerObjectH', function() {
     ok(typeof canvas.centerObjectH == 'function');
     var rect = makeRect({ left: 102, top: 202 });


### PR DESCRIPTION
The new toDataURL code in 1.6.5 uses `cropping.width` to calculate `scaledHeight`. It should use `cropping.height` .