### PR TITLE
Fix event listeners after itext removal

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -75,9 +75,9 @@
           });
         }
       }).bind(this);
-      canvas.on('selection:cleared', canvas._canvasSelectionClearedHanlder);
-      canvas.on('object:selected', canvas._canvasSelectionClearedHanlder);
-      canvas.on('mouse:up', canvas._mouseUpHandler);
+      canvas.on('selection:cleared', canvas._canvasITextSelectionClearedHanlder);
+      canvas.on('object:selected', canvas._canvasITextSelectionClearedHanlder);
+      canvas.on('mouse:up', canvas._mouseUpITextHandler);
     },
 
     /**
@@ -85,9 +85,9 @@
      * @private
      */
     _removeCanvasHandlers: function(canvas) {
-      canvas.off('selection:cleared', canvas._canvasSelectionClearedHanlder);
-      canvas.off('object:selected', canvas._canvasSelectionClearedHanlder);
-      canvas.off('mouse:up', canvas._mouseUpHandler);
+      canvas.off('selection:cleared', canvas._canvasITextSelectionClearedHanlder);
+      canvas.off('object:selected', canvas._canvasITextSelectionClearedHanlder);
+      canvas.off('mouse:up', canvas._mouseUpITextHandler);
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -785,7 +785,6 @@
       this.backgroundColor = '';
       this.overlayColor = ''
       if (this._hasITextHandlers) {
-        console.log(this._canvasITextSelectionClearedHanlder, this._mouseUpITextHandler)
         this.off('selection:cleared', this._canvasITextSelectionClearedHanlder);
         this.off('object:selected', this._canvasITextSelectionClearedHanlder);
         this.off('mouse:up', this._mouseUpITextHandler);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -785,9 +785,10 @@
       this.backgroundColor = '';
       this.overlayColor = ''
       if (this._hasITextHandlers) {
-        this.off('selection:cleared', this._canvasSelectionClearedHanlder);
-        this.off('object:selected', this._canvasSelectionClearedHanlder);
-        this.off('mouse:up', this._mouseUpHandler);
+        console.log(this._canvasITextSelectionClearedHanlder, this._mouseUpITextHandler)
+        this.off('selection:cleared', this._canvasITextSelectionClearedHanlder);
+        this.off('object:selected', this._canvasITextSelectionClearedHanlder);
+        this.off('mouse:up', this._mouseUpITextHandler);
         this._iTextInstances = null;
         this._hasITextHandlers = false;
       }


### PR DESCRIPTION
Bad function naming was causing a full clear of the event listener. breaking normal fabric behaviour.