### PR TITLE
adding object properties of snapAngle and snapThreshold to enable object snapping.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -971,17 +971,18 @@
       if (angle < 0) {
         angle = 360 + angle;
       }
-      
+
       angle %= 360
 
-      var snapAngle  = t.target.snapAngle;
-      var snapThreshold  = t.target.snapThreshold || snapAngle;
-      var rightAngleLocked = Math.ceil(angle / snapAngle) * snapAngle;
-      var leftAngleLocked = Math.floor(angle / snapAngle) * snapAngle;
-  
+      var snapAngle  = t.target.snapAngle,
+          snapThreshold  = t.target.snapThreshold || snapAngle,
+          rightAngleLocked = Math.ceil(angle / snapAngle) * snapAngle,
+          leftAngleLocked = Math.floor(angle / snapAngle) * snapAngle;
+
       if (Math.abs(angle - leftAngleLocked) < snapThreshold) {
         angle = leftAngleLocked;
-      } else if (Math.abs(angle - rightAngleLocked) < snapThreshold) {
+      }
+      else if (Math.abs(angle - rightAngleLocked) < snapThreshold) {
         angle = rightAngleLocked;
       }
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -256,6 +256,23 @@
     preserveObjectStacking: false,
 
     /**
+     * Indicates the angle that an object will lock to while rotating.
+     * @type Number
+     * @since 1.6.7
+     * @default
+     */
+    snapAngle: 0,
+
+    /**
+     * Indicates the distance from the snapAngle the rotation will lock to the snapAngle.
+     * When `null`, the snapThreshold will default to the snapAngle.
+     * @type null|Number
+     * @since 1.6.7
+     * @default
+     */
+    snapThreshold: null,
+
+    /**
      * Indicates if the right click on canvas can output the context menu or not
      * @type Boolean
      * @since 1.6.5
@@ -954,8 +971,21 @@
       if (angle < 0) {
         angle = 360 + angle;
       }
+      
+      angle %= 360
 
-      t.target.angle = angle % 360;
+      var snapAngle  = t.target.snapAngle;
+      var snapThreshold  = t.target.snapThreshold || snapAngle;
+      var rightAngleLocked = Math.ceil(angle / snapAngle) * snapAngle;
+      var leftAngleLocked = Math.floor(angle / snapAngle) * snapAngle;
+  
+      if (Math.abs(angle - leftAngleLocked) < snapThreshold) {
+        angle = leftAngleLocked;
+      } else if (Math.abs(angle - rightAngleLocked) < snapThreshold) {
+        angle = rightAngleLocked;
+      }
+
+      t.target.angle = angle;
       return true;
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -965,7 +965,8 @@
 
       var lastAngle = atan2(t.ey - t.top, t.ex - t.left),
           curAngle = atan2(y - t.top, x - t.left),
-          angle = radiansToDegrees(curAngle - lastAngle + t.theta);
+          angle = radiansToDegrees(curAngle - lastAngle + t.theta),
+          hasRoated = true;
 
       // normalize angle to positive value
       if (angle < 0) {
@@ -974,20 +975,26 @@
 
       angle %= 360
 
-      var snapAngle  = t.target.snapAngle,
-          snapThreshold  = t.target.snapThreshold || snapAngle,
-          rightAngleLocked = Math.ceil(angle / snapAngle) * snapAngle,
-          leftAngleLocked = Math.floor(angle / snapAngle) * snapAngle;
+      if (t.target.snapAngle > 0) {
+        var snapAngle  = t.target.snapAngle,
+            snapThreshold  = t.target.snapThreshold || snapAngle,
+            rightAngleLocked = Math.ceil(angle / snapAngle) * snapAngle,
+            leftAngleLocked = Math.floor(angle / snapAngle) * snapAngle;
 
-      if (Math.abs(angle - leftAngleLocked) < snapThreshold) {
-        angle = leftAngleLocked;
-      }
-      else if (Math.abs(angle - rightAngleLocked) < snapThreshold) {
-        angle = rightAngleLocked;
+        if (Math.abs(angle - leftAngleLocked) < snapThreshold) {
+          angle = leftAngleLocked;
+        }
+        else if (Math.abs(angle - rightAngleLocked) < snapThreshold) {
+          angle = rightAngleLocked;
+        }
+
+        if (t.target.angle === angle) {
+          hasRoated = false
+        }
       }
 
       t.target.angle = angle;
-      return true;
+      return hasRoated;
     },
 
     /**


### PR DESCRIPTION
Adds a way to set an angle interval to snap to during rotation (`snapAngle`) and the ability to set the threshold of how far away it snaps to that angle (`snapThreshold`).

When the `snapThreshold` is null (the default) it will use the `snapAngle` until the user sets the `snapThreshold`. This is good because it makes the api easier to use and also setting the `snapAngle` will feel more obvious with the threshold and the angle the same.

Here is an example of just the `snapAngle` set toe 45:
![fabric](https://cloud.githubusercontent.com/assets/87616/19794782/33c0a23c-9ca3-11e6-8250-076ecde78521.gif)


@asturur mentioned adding a shift or alt modifier key to turn the behavior off but I think that might be better handled in code like so:
```
rect.on('rotating', function(options) {
  if(options.e.shiftKey) {
    this.snapAngle = 0;
  } else {
    this.snapAngle = 45;
  }
});
```
To me this keep fabric feeling more like a tool, while assigning predetermined modifier keys to disable behavior makes the library feel more opinionated then a tool should be. This code to disable the snap behavior could easily go in a tutorial somewhere.

close #3369