### PR TITLE
Trigger mouse over on canvas enter

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -148,10 +148,8 @@
      */
     _onMouseEnter: function(e) {
       if (!this.findTarget(e)) {
-        var target = this._hoveredTarget || null;
-        this.fire('mouse:over', { target: target, e: e });
+        this.fire('mouse:over', { target: null, e: e });
         this._hoveredTarget = null;
-        target && target.fire('mouseenter', { e: e });
       }
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -44,6 +44,7 @@
       addListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
       addListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       addListener(this.upperCanvasEl, 'mouseout', this._onMouseOut);
+      addListener(this.upperCanvasEl, 'mouseenter', this._onMouseEnter);
       addListener(this.upperCanvasEl, 'wheel', this._onMouseWheel);
       addListener(this.upperCanvasEl, 'contextmenu', this._onContextMenu);
 
@@ -75,6 +76,7 @@
       this._onOrientationChange = this._onOrientationChange.bind(this);
       this._onMouseWheel = this._onMouseWheel.bind(this);
       this._onMouseOut = this._onMouseOut.bind(this);
+      this._onMouseEnter = this._onMouseEnter.bind(this);
       this._onContextMenu = this._onContextMenu.bind(this);
     },
 
@@ -87,6 +89,7 @@
       removeListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
       removeListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       removeListener(this.upperCanvasEl, 'mouseout', this._onMouseOut);
+      removeListener(this.upperCanvasEl, 'mouseenter', this._onMouseEnter);
       removeListener(this.upperCanvasEl, 'wheel', this._onMouseWheel);
       removeListener(this.upperCanvasEl, 'contextmenu', this._onContextMenu);
 
@@ -137,6 +140,17 @@
       this.fire('mouse:out', { target: target, e: e });
       this._hoveredTarget = null;
       target && target.fire('mouseout', { e: e });
+    },
+
+    /**
+     * @private
+     * @param {Event} e Event object fired on mouseenter
+     */
+    _onMouseEnter: function(e) {
+      var target = this._hoveredTarget;
+      this.fire('mouse:over', { target: target, e: e });
+      this._hoveredTarget = null;
+      target && target.fire('mouseenter', { e: e });
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -147,10 +147,12 @@
      * @param {Event} e Event object fired on mouseenter
      */
     _onMouseEnter: function(e) {
-      var target = this._hoveredTarget;
-      this.fire('mouse:over', { target: target, e: e });
-      this._hoveredTarget = null;
-      target && target.fire('mouseenter', { e: e });
+      if (!this.findTarget(e)) {
+        var target = this._hoveredTarget || null;
+        this.fire('mouse:over', { target: target, e: e });
+        this._hoveredTarget = null;
+        target && target.fire('mouseenter', { e: e });
+      }
     },
 
     /**


### PR DESCRIPTION
As talked about in #3384 this adds the existing `mouse:over` event to fire when the mouse enters the canvas.

If the mouse enters the canvas and there is no target the fire the event. We need to do a check if there is a target, other wise the event will fire 2 times on entering the canvas with an object on the edge. once with null and once with the target,
