### PR TITLE
includeDefaults for background and overlay

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1042,7 +1042,7 @@
         objects: this._toObjects(methodName, propertiesToInclude)
       };
 
-      extend(data, this.__serializeBgOverlay(propertiesToInclude));
+      extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude));
 
       fabric.util.populateWithProperties(this, data, propertiesToInclude);
 
@@ -1081,7 +1081,7 @@
     /**
      * @private
      */
-    __serializeBgOverlay: function(propertiesToInclude) {
+    __serializeBgOverlay: function(methodName, propertiesToInclude) {
       var data = {
         background: (this.backgroundColor && this.backgroundColor.toObject)
           ? this.backgroundColor.toObject(propertiesToInclude)
@@ -1094,10 +1094,10 @@
           : this.overlayColor;
       }
       if (this.backgroundImage) {
-        data.backgroundImage = this.backgroundImage.toObject(propertiesToInclude);
+        data.backgroundImage = this._toObject(this.backgroundImage, methodName, propertiesToInclude);
       }
       if (this.overlayImage) {
-        data.overlayImage = this.overlayImage.toObject(propertiesToInclude);
+        data.overlayImage = this._toObject(this.overlayImage, methodName, propertiesToInclude);
       }
 
       return data;

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -862,6 +862,16 @@
     equal(canvas.toObject().objects[0].type, rect.type);
   });
 
+  test('toObject non includeDefaultValues', function() {
+    canvas.includeDefaultValues = false;
+    var rect = makeRect();
+    canvas.add(rect);
+    var cObject = canvas.toObject();
+    var expectedRect = { type: 'rect', width: 10, height: 10 };
+    deepEqual(cObject.objects[0], expectedRect, 'Rect should be exported withoud defaults');
+    canvas.includeDefaultValues = true;
+  });
+
   test('toObject excludeFromExport', function() {
     var rect = makeRect(), rect2 = makeRect(), rect3 = makeRect();
     canvas.clear();


### PR DESCRIPTION
closes #3413 

Reuse StaticCanvas function _toObject that handles the 'includeDefaults' flag.