### PR TITLE
Fix itext cursor trail on initDimensions

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -307,6 +307,21 @@
     },
 
     /**
+     * Initialize text dimensions. Render all text on given context
+     * or on a offscreen canvas to get the text width with measureText.
+     * Updates this.width and this.height with the proper values.
+     * Does not return dimensions.
+     * @param {CanvasRenderingContext2D} [ctx] Context to render on
+     * @private
+     */
+    _initDimensions: function(ctx) {
+      if (!ctx) {
+        this.clearContextTop();
+      }
+      this.callSuper('_initDimensions', ctx);
+    },
+
+    /**
      * @private
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Boolean} noTransform

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -773,7 +773,7 @@
      * @type Boolean
      * @default
      */
-    statefullCache:            false,
+    statefullCache:            true,
 
     /**
      * When `true`, cache does not get updated during scaling. The picture will get blocky if scaled
@@ -851,10 +851,10 @@
           dim = this._getNonTransformedDimensions(),
           retina = this.canvas && this.canvas._isRetinaScaling() ? fabric.devicePixelRatio : 1,
           zoomX = objectScale.scaleX * zoom * retina,
-          zoomY = objectScale.scaleY * zoom * retina;
-      if (zoomX !== this.zoomX || zoomY !== this.zoomY) {
-        var width = dim.x * zoomX,
-            height = dim.y * zoomY;
+          zoomY = objectScale.scaleY * zoom * retina,
+          width = dim.x * zoomX,
+          height = dim.y * zoomY;
+      if (width !== this.cacheWidth || height !== this.cacheHeight) {
         this._cacheCanvas.width = width;
         this._cacheCanvas.height = height;
         this._cacheContext.translate(width / 2, height / 2);

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -377,7 +377,6 @@
       if (!ctx) {
         ctx = fabric.util.createCanvasElement().getContext('2d');
         this._setTextStyles(ctx);
-        this.clearContextTop();
       }
       this._textLines = this._splitTextIntoLines();
       this._clearCache();

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -377,6 +377,7 @@
       if (!ctx) {
         ctx = fabric.util.createCanvasElement().getContext('2d');
         this._setTextStyles(ctx);
+        this.clearContextTop();
       }
       this._textLines = this._splitTextIntoLines();
       this._clearCache();


### PR DESCRIPTION
Some setProperty method are calling initDimension internally.
This was recalculating width and height before rendering and so the clearUpperCanvas logic was uneffective.

Now initDimensions has its own call to clearUpperCanvas

Also fix some caching issue on objectCache

close #3402