### PR TITLE
fix for scale and flip

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -358,13 +358,13 @@
       var matrix = object.calcTransformMatrix(),
           options = fabric.util.qrDecompose(matrix),
           center = new fabric.Point(options.translateX, options.translateY);
-      object.scaleX = options.scaleX;
-      object.scaleY = options.scaleY;
+      object.flipX = false;
+      object.flipY = false;
+      object.set('scaleX', options.scaleX);
+      object.set('scaleY', options.scaleY);
       object.skewX = options.skewX;
       object.skewY = options.skewY;
       object.angle = options.angle;
-      object.flipX = false;
-      object.flipY = false;
       object.setPositionByOrigin(center, 'center', 'center');
       return object;
     },


### PR DESCRIPTION
When a group is destroyed scale may result in negative number.
Fabric tolerate that to a certain extent. Is better to have a positive scale and a flip sign.

close #3458