### PR TITLE
add blur on textarea element

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -558,6 +558,7 @@
       this.selectable = true;
 
       this.selectionEnd = this.selectionStart;
+      this.hiddenTextarea.blur && this.hiddenTextarea.blur();
       this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
       this.hiddenTextarea = null;
 


### PR DESCRIPTION
close #3374 

On some ios and other mobile device looks like an explicit blur is required to dismiss keyboard.