### PR TITLE
Update shiftKey & altKey values during __onMouseMove()

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -638,6 +638,8 @@
 
       transform.reset = false;
       transform.target.isMoving = true;
+      transform.shiftKey = e.shiftKey;
+      transform.altKey = e[this.centeredKey];
 
       this._beforeScaleTransform(e, transform);
       this._performTransformAction(e, transform, pointer);


### PR DESCRIPTION
Currently the values of `shiftKey` & `altKey` are set on mouseDown and only the cached values are referenced during mouseMove events. This means if you start a transform and then want to hold `alt` to `centerTransform` you can't until you stop transforming and hold `alt` before starting the transform.

This change updates the values during mouseMove which lets you start a transform and add the key modifier on the fly.