### PR TITLE
Fixestocachepolygon

### DIFF
--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -11,6 +11,11 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push(
+    'radius'
+  );
+
   /**
    * Circle class
    * @class fabric.Circle
@@ -46,6 +51,8 @@
      * @default 2Pi
      */
     endAngle: pi * 2,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -11,6 +11,12 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push(
+    'rx',
+    'ry'
+  );
+
   /**
    * Ellipse class
    * @class fabric.Ellipse
@@ -40,6 +46,8 @@
      * @default
      */
     ry:   0,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -12,6 +12,14 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push(
+    'x1',
+    'x2',
+    'y1',
+    'y2'
+  );
+
   /**
    * Line class
    * @class fabric.Line
@@ -54,6 +62,8 @@
      * @default
      */
     y2: 0,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -29,6 +29,9 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push('path');
+
   /**
    * Path class
    * @class fabric.Path
@@ -65,6 +68,8 @@
      * @default
      */
     minY: 0,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -156,22 +156,21 @@
      * @param {Boolean} noTransform
      */
     commonRender: function(ctx, noTransform) {
-      var point, len = this.points.length;
+      var point, len = this.points.length,
+          x = noTransform ? 0 : this.pathOffset.x,
+          y = noTransform ? 0 : this.pathOffset.y;
 
       if (!len || isNaN(this.points[len - 1].y)) {
         // do not draw if no points or odd points
         // NaN comes from parseFloat of a empty string in parser
         return false;
       }
-      ctx.save()
-      noTransform || ctx.translate(-this.pathOffset.x, -this.pathOffset.y);
       ctx.beginPath();
-      ctx.moveTo(this.points[0].x, this.points[0].y);
+      ctx.moveTo(this.points[0].x - x, this.points[0].y - y);
       for (var i = 0; i < len; i++) {
         point = this.points[i];
-        ctx.lineTo(point.x, point.y);
+        ctx.lineTo(point.x - x, point.y - y);
       }
-      ctx.restore();
       return true;
     },
 

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -13,6 +13,9 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push('points');
+
   /**
    * Polygon class
    * @class fabric.Polygon
@@ -48,6 +51,8 @@
      * @default
      */
     minY: 0,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor
@@ -158,7 +163,7 @@
         // NaN comes from parseFloat of a empty string in parser
         return false;
       }
-
+      ctx.save()
       noTransform || ctx.translate(-this.pathOffset.x, -this.pathOffset.y);
       ctx.beginPath();
       ctx.moveTo(this.points[0].x, this.points[0].y);
@@ -166,6 +171,7 @@
         point = this.points[i];
         ctx.lineTo(point.x, point.y);
       }
+      ctx.restore();
       return true;
     },
 

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -9,6 +9,9 @@
     return;
   }
 
+  var cacheProperties = fabric.Object.prototype.cacheProperties.concat();
+  cacheProperties.push('points');
+
   /**
    * Polyline class
    * @class fabric.Polyline
@@ -44,6 +47,8 @@
      * @default
      */
     minY: 0,
+
+    cacheProperties: cacheProperties,
 
     /**
      * Constructor

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -11,7 +11,7 @@
   }
 
   var stateProperties = fabric.Object.prototype.stateProperties.concat();
-  stateProperties.push('rx', 'ry', 'x', 'y');
+  stateProperties.push('rx', 'ry');
 
   /**
    * Rectangle class


### PR DESCRIPTION
closes #3486

the ctx.translate() was never restored on the cacheCanvas because it was relying on the parent function .restiore().
