### PR TITLE
Ensure clone invokes callback in all cases

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1471,10 +1471,15 @@
      * @return {fabric.Object} clone of an instance
      */
     clone: function(callback, propertiesToInclude) {
-      if (this.constructor.fromObject) {
+      if (this.constructor.fromObject instanceof Function) {
         return this.constructor.fromObject(this.toObject(propertiesToInclude), callback);
       }
-      return new fabric.Object(this.toObject(propertiesToInclude));
+      var cloned = new fabric.Object(this.toObject(propertiesToInclude)); 
+      if(!(callback instanceof Function)) {
+        return cloned;
+      }
+      setTimeout(callback.bind(null, cloned), 0);
+      return cloned;
     },
 
     /**


### PR DESCRIPTION
> Clones an instance, some objects are async, so using callback method will work for every object. 

This should mean that `callback` is invoked no matter what, however if `this.constructor.fromObject` is not a function then it should never be invoked. 

This solves the issue by invoking `callback` if the value is just being returned. 

`setTimeout` is used to ensure `callback` is invoked in an *async* fashion