### PR TITLE
Fix custom fonts (requires libpango)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site"
   },
   "optionalDependencies": {
-    "canvas": "1.6.x",
+    "canvas": "~1.6.1",
     "jsdom": "3.x.x",
     "xmldom": "0.1.x"
   },


### PR DESCRIPTION
Node-canvas fixed custom font loading in v1.6.1 by merging this PR: https://github.com/Automattic/node-canvas/pull/715
It was broken for almost 2 years, although it could be avoided by removing libpango and reinstalling node-canvas (see #3272), that also removed some other functionality (which I'm not sure fabric uses), and with 1.6.1 they explicitly require libpango.

I think fabric should use canvas ~1.6.1 (same as "1.6.x", but excluding 1.6.0), because otherwise the same version of fabric could use different versions of node-canvas and this problem could still occur for people who have installed canvas explicitly or through other dependencies.

Fixes #2514, #3208 and #3272 (duplicates)