### PR TITLE
Added missing semicolons to canvas.class.js

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -972,7 +972,7 @@
         angle = 360 + angle;
       }
 
-      angle %= 360
+      angle %= 360;
 
       if (t.target.snapAngle > 0) {
         var snapAngle  = t.target.snapAngle,
@@ -988,7 +988,7 @@
         }
 
         if (t.target.angle === angle) {
-          hasRoated = false
+          hasRoated = false;
         }
       }
 


### PR DESCRIPTION
Hi. 

Looks like there were couple of semicolons missing in canvas.class.js. 

These have been now amended. 

Thank you. 