### PR TITLE
Fix for itext clearing out the selection area

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -266,6 +266,11 @@
     _shouldRender: function(target, pointer) {
       var activeObject = this.getActiveGroup() || this.getActiveObject();
 
+      if (activeObject && activeObject.isEditing) {
+        // if we mouse up/down over a editing textbox a cursor change,
+        // there is no need to re render
+        return false;
+      }
       return !!(
         (target && (
           target.isMoving ||

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -85,7 +85,14 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
     e.stopImmediatePropagation();
     e.preventDefault();
-    this.canvas && this.canvas.renderAll();
+    if (e.keyCode >= 33 && e.keyCode <= 40) {
+      // if i press an arrow key just update selection
+      this.clearContextTop();
+      this.renderCursorOrSelection();
+    }
+    else {
+      this.canvas && this.canvas.renderAll();
+    }
   },
 
   /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -329,6 +329,10 @@
     render: function(ctx, noTransform) {
       this.clearContextTop();
       this.callSuper('render', ctx, noTransform);
+      // clear the cursorOffsetCache, so we ensure to calculate once per renderCursor
+      // the correct position but not at every cursor animation.
+      this.cursorOffsetCache = { };
+      this.renderCursorOrSelection();
     },
 
     /**
@@ -338,10 +342,6 @@
     _render: function(ctx) {
       this.callSuper('_render', ctx);
       this.ctx = ctx;
-      // clear the cursorOffsetCache, so we ensure to calculate once per renderCursor
-      // the correct position but not at every cursor animation.
-      this.cursorOffsetCache = { };
-      this.renderCursorOrSelection();
     },
 
     /**


### PR DESCRIPTION
closes #3505

There where errors and optimization possibilities:

1) after a mouse up the text was redrawn, using a cachied copied. the code for drawing the selection was inside the cache creation, and so it was not executed during the faster drawing. this was the main error.

2) after mouse up there was no need to re render, this is an optimization

3) during keypresses of arrows where just the cursor selection changes, there is no need for a full canvas redraw. this is an optimization