### PR TITLE
Fix for event not firing

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -687,7 +687,7 @@
           this.setCursor(target.moveCursor || this.moveCursor);
         }
       }
-      transform.actionPerformed = actionPerformed;
+      transform.actionPerformed = transform.actionPerformed || actionPerformed;
     },
 
     /**


### PR DESCRIPTION
closes #3469

Root cause discovered by @dennisrjohn, i sticked to the simplest fix possible. If the transformation has at least one action performed it will fire the event.