### PR TITLE
delete stylemap before wrapping text

### DIFF
--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -329,6 +329,7 @@
     _splitTextIntoLines: function(ctx) {
       ctx = ctx || this.ctx;
       var originalAlign = this.textAlign;
+      this._styleMap = null;
       ctx.save();
       this._setTextStyles(ctx);
       this.textAlign = 'left';


### PR DESCRIPTION
Delete style map from textbox before wrapping lines.
The function `getStyleDeclaration` use styleMap if available.
But in that moment we refer to text using its real index for line and char.

close #3496