### PR TITLE
Added missing semicolon to build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -287,7 +287,7 @@ else if (buildSh) {
   path = '../fabricjs.com/build/files/' + fileName + '.min.js';
   fs.appendFile('build.sh',
     'echo "' + escapedHeader + '" > ' + path + ' && cat ' +
-    minFilesStr + ' >> ' + path + '\n')
+    minFilesStr + ' >> ' + path + '\n');
 }
 else {
   // change the current working directory


### PR DESCRIPTION
Hi.

Looks like build.js was missing a semicolon on line 290. 

This has been now amended.

Thank you.
