### PR TITLE
Added missing semicolon to canvas_events.mixin.js

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -186,7 +186,7 @@
      */
     _onContextMenu: function (e) {
       if (this.stopContextMenu) {
-        e.stopPropagation()
+        e.stopPropagation();
         e.preventDefault();
       }
       return false;


### PR DESCRIPTION
Hello.

Looks like there was a missing semicolon in src/mixins/canvas_events.mixin.js, line 189.

This has been now amended. 

Thank you. 