### PR TITLE
Added missing semicolon to canvas_events.serialization.js

### DIFF
--- a/src/mixins/canvas_serialization.mixin.js
+++ b/src/mixins/canvas_serialization.mixin.js
@@ -126,7 +126,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         _this[property] = enlivedObject[0];
         loaded[property] = true;
         callback && callback();
-      })
+      });
     }
     else {
       this['set' + fabric.util.string.capitalize(property, true)](value, function() {


### PR DESCRIPTION
Hi.

Looks like there was a missing semicolon in src/mixins/canvas_serialization.mixin.js, line 129.

This has been now amended.

Thank you.
