### PR TITLE
Added an additional check for the blur event on hiddenTextarea

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -563,9 +563,12 @@
       this.selectable = true;
 
       this.selectionEnd = this.selectionStart;
-      this.hiddenTextarea && this.hiddenTextarea.blur && this.hiddenTextarea.blur();
-      this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
-      this.hiddenTextarea = null;
+
+      if (this.hiddenTextarea) {
+        this.hiddenTextarea.blur && this.hiddenTextarea.blur();
+        this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
+        this.hiddenTextarea = null;
+      }
 
       this.abortCursorAnimation();
       this._restoreEditingProps();

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -563,7 +563,7 @@
       this.selectable = true;
 
       this.selectionEnd = this.selectionStart;
-      this.hiddenTextarea.blur && this.hiddenTextarea.blur();
+      this.hiddenTextarea && this.hiddenTextarea.blur && this.hiddenTextarea.blur();
       this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
       this.hiddenTextarea = null;
 


### PR DESCRIPTION
When having a Textbox in the canvas with some text in it and `canvas.deactivateAllWithDispatch()` is called the `this.hiddenTextarea` might be null sometimes.

This check is also made on the following line so it made sens to also do it here.
Hope this helps
