### PR TITLE
Remove hoveredTarget reference if object is removed

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1380,6 +1380,9 @@
         this.fire('selection:cleared', { target: obj });
         obj.fire('deselected');
       }
+      if (this._hoveredTarget === obj) {
+        this._hoveredTarget = null;
+      }
       this.callSuper('_onObjectRemoved', obj);
     },
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -255,6 +255,14 @@
     canvas.remove(rect4);
     equal(canvas.isEmpty(), true, 'canvas should be empty');
   });
+  
+  test('remove actual hovered target', function() {
+    var rect1 = makeRect();
+    canvas.add(rect1);
+    canvas._hoveredTarget = rect1;
+    canvas.remove(rect1);
+    equal(canvas._hoveredTarget, null, 'reference to hovered target should be removed');
+  });
 
   test('before:selection:cleared', function() {
     var isFired = false;

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -255,7 +255,7 @@
     canvas.remove(rect4);
     equal(canvas.isEmpty(), true, 'canvas should be empty');
   });
-  
+
   test('remove actual hovered target', function() {
     var rect1 = makeRect();
     canvas.add(rect1);


### PR DESCRIPTION
Avoid to fire an uncorrect object mouseout if we are removing an object that we just hovered.
