### PR TITLE
fire `deselected` on activeObject switch.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1350,8 +1350,12 @@
      * @param {Object} object
      */
     _setActiveObject: function(object) {
-      if (this._activeObject) {
-        this._activeObject.set('active', false);
+      var obj = this._activeObject;
+      if (obj) {
+        obj.set('active', false);
+        if (obj.isEditing && typeof obj.exitEditing === 'function') {
+          obj.exitEditing();
+        }
       }
       this._activeObject = object;
       object.set('active', true);
@@ -1406,8 +1410,12 @@
      * @private
      */
     _discardActiveObject: function() {
-      if (this._activeObject) {
-        this._activeObject.set('active', false);
+      var obj = this._activeObject;
+      if (obj) {
+        obj.set('active', false);
+        if (obj.isEditing && typeof obj.exitEditing === 'function') {
+          obj.exitEditing();
+        }
       }
       this._activeObject = null;
     },

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1353,7 +1353,7 @@
       var obj = this._activeObject;
       if (obj) {
         obj.set('active', false);
-        if (obj.onDeselect && typeof obj.onDeselect === 'function') {
+        if (object !== obj && obj.onDeselect && typeof obj.onDeselect === 'function') {
           obj.onDeselect();
         }
       }

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1366,7 +1366,7 @@
      */
     setActiveObject: function (object, e) {
       var currentActiveObject = this.getActiveObject();
-      if (currentActiveObject !== object) {
+      if (currentActiveObject && currentActiveObject !== object) {
         currentActiveObject.fire('deselected', { e: e });
       }
       this._setActiveObject(object);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1353,8 +1353,8 @@
       var obj = this._activeObject;
       if (obj) {
         obj.set('active', false);
-        if (obj.isEditing && typeof obj.exitEditing === 'function') {
-          obj.exitEditing();
+        if (obj.onDeselect && typeof obj.onDeselect === 'function') {
+          obj.onDeselect();
         }
       }
       this._activeObject = object;
@@ -1413,8 +1413,8 @@
       var obj = this._activeObject;
       if (obj) {
         obj.set('active', false);
-        if (obj.isEditing && typeof obj.exitEditing === 'function') {
-          obj.exitEditing();
+        if (obj.onDeselect && typeof obj.onDeselect === 'function') {
+          obj.onDeselect();
         }
       }
       this._activeObject = null;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1365,6 +1365,10 @@
      * @chainable
      */
     setActiveObject: function (object, e) {
+      var currentActiveObject = this.getActiveObject();
+      if (currentActiveObject !== object) {
+        currentActiveObject.fire('deselected', { e: e });
+      }
       this._setActiveObject(object);
       this.renderAll();
       this.fire('object:selected', { target: object, e: e });
@@ -1409,17 +1413,22 @@
     },
 
     /**
-     * Discards currently active object and fire events
+     * Discards currently active object and fire events. If the function is called by fabric
+     * as a consequence of a mouse event, the event is passed as a parmater and
+     * sent to the fire function for the custom events. When used as a method the
+     * e param does not have any application.
      * @param {event} e
      * @return {fabric.Canvas} thisArg
      * @chainable
      */
     discardActiveObject: function (e) {
       var activeObject = this._activeObject;
-      this.fire('before:selection:cleared', { target: activeObject, e: e });
-      this._discardActiveObject();
-      this.fire('selection:cleared', { e: e });
-      activeObject && activeObject.fire('deselected', { e: e });
+      if (activeObject) {
+        this.fire('before:selection:cleared', { target: activeObject, e: e });
+        this._discardActiveObject();
+        this.fire('selection:cleared', { e: e });
+        activeObject.fire('deselected', { e: e });
+      }
       return this;
     },
 
@@ -1435,7 +1444,10 @@
     },
 
     /**
-     * Sets active group to a specified one
+     * Sets active group to a specified one. If the function is called by fabric
+     * as a consequence of a mouse event, the event is passed as a parmater and
+     * sent to the fire function for the custom events. When used as a method the
+     * e param does not have any application.
      * @param {fabric.Group} group Group to set as a current one
      * @param {Event} e Event object
      * @return {fabric.Canvas} thisArg
@@ -1470,15 +1482,20 @@
     },
 
     /**
-     * Discards currently active group and fire events
+     * Discards currently active group and fire events If the function is called by fabric
+     * as a consequence of a mouse event, the event is passed as a parmater and
+     * sent to the fire function for the custom events. When used as a method the
+     * e param does not have any application.
      * @return {fabric.Canvas} thisArg
      * @chainable
      */
     discardActiveGroup: function (e) {
       var g = this.getActiveGroup();
-      this.fire('before:selection:cleared', { e: e, target: g });
-      this._discardActiveGroup();
-      this.fire('selection:cleared', { e: e });
+      if (g) {
+        this.fire('before:selection:cleared', { e: e, target: g });
+        this._discardActiveGroup();
+        this.fire('selection:cleared', { e: e });
+      }
       return this;
     },
 
@@ -1502,21 +1519,17 @@
     },
 
     /**
-     * Deactivates all objects and dispatches appropriate events
+     * Deactivates all objects and dispatches appropriate events If the function is called by fabric
+     * as a consequence of a mouse event, the event is passed as a parmater and
+     * sent to the fire function for the custom events. When used as a method the
+     * e param does not have any application.
      * @return {fabric.Canvas} thisArg
      * @chainable
      */
     deactivateAllWithDispatch: function (e) {
-      var activeGroup = this.getActiveGroup(),
-          activeObject = this.getActiveObject();
-      if (activeObject || activeGroup) {
-        this.fire('before:selection:cleared', { target: activeObject || activeGroup, e: e });
-      }
+      this.discardActiveGroup(e);
+      this.discardActiveObject(e);
       this.deactivateAll();
-      if (activeObject || activeGroup) {
-        this.fire('selection:cleared', { e: e, target: activeObject });
-        activeObject && activeObject.fire('deselected');
-      }
       return this;
     },
 

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -15,17 +15,9 @@
       this.mouseMoveHandler = this.mouseMoveHandler.bind(this);
     },
 
-    /**
-     * Initializes "selected" event handler
-     */
-    initSelectedHandler: function() {
-      this.on('selected', function() {
-
-        var _this = this;
-        setTimeout(function() {
-          _this.selected = true;
-        }, 100);
-      });
+    onDeselect: function() {
+      this.isEditing && this.exitEditing();
+      this.selected = false;
     },
 
     /**
@@ -574,7 +566,6 @@
         this.canvas.fire('text:editing:exited', { target: this });
         isTextChanged && this.canvas.fire('object:modified', { target: this });
       }
-console.trace()
       return this;
     },
 

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -581,7 +581,7 @@
         this.canvas.fire('text:editing:exited', { target: this });
         isTextChanged && this.canvas.fire('object:modified', { target: this });
       }
-
+console.trace()
       return this;
     },
 

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -66,9 +66,6 @@
      * @private
      */
     _initCanvasHandlers: function(canvas) {
-      canvas._canvasITextSelectionClearedHanlder = (function() {
-        fabric.IText.prototype.exitEditingOnOthers(canvas);
-      }).bind(this);
       canvas._mouseUpITextHandler = (function() {
         if (canvas._iTextInstances) {
           canvas._iTextInstances.forEach(function(obj) {
@@ -76,8 +73,6 @@
           });
         }
       }).bind(this);
-      canvas.on('selection:cleared', canvas._canvasITextSelectionClearedHanlder);
-      canvas.on('object:selected', canvas._canvasITextSelectionClearedHanlder);
       canvas.on('mouse:up', canvas._mouseUpITextHandler);
     },
 
@@ -86,8 +81,6 @@
      * @private
      */
     _removeCanvasHandlers: function(canvas) {
-      canvas.off('selection:cleared', canvas._canvasITextSelectionClearedHanlder);
-      canvas.off('object:selected', canvas._canvasITextSelectionClearedHanlder);
       canvas.off('mouse:up', canvas._mouseUpITextHandler);
     },
 

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -61,7 +61,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * Initializes event handlers related to cursor or selection
    */
   initCursorSelectionHandlers: function() {
-    this.initSelectedHandler();
     this.initMousedownHandler();
     this.initMouseupHandler();
     this.initClicks();

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -783,8 +783,6 @@
       this.backgroundColor = '';
       this.overlayColor = '';
       if (this._hasITextHandlers) {
-        this.off('selection:cleared', this._canvasITextSelectionClearedHanlder);
-        this.off('object:selected', this._canvasITextSelectionClearedHanlder);
         this.off('mouse:up', this._mouseUpITextHandler);
         this._iTextInstances = null;
         this._hasITextHandlers = false;


### PR DESCRIPTION
close #3666 
close #3685 

introduced onDeselect method for object, similiar to onObjectAdded for canvas.
It handles some small logic for Itext that i do not want to be handled with events.
Removed `selected` envent handler for Itext. Was using a setTimeout and was not really usefull.
