### PR TITLE
fix reload from json

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1000,7 +1000,7 @@
       var prototype = fabric.util.getKlass(object.type).prototype,
           stateProperties = prototype.stateProperties;
       stateProperties.forEach(function(prop) {
-        if (object[prop] === prototype[prop]) {
+        if (object[prop] === prototype[prop] && (prop !== 'top' && prop !== 'left')) {
           delete object[prop];
         }
         var isArray = Object.prototype.toString.call(object[prop]) === '[object Array]' &&

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1000,7 +1000,7 @@
       var prototype = fabric.util.getKlass(object.type).prototype,
           stateProperties = prototype.stateProperties;
       stateProperties.forEach(function(prop) {
-        if (object[prop] === prototype[prop] && (prop !== 'top' && prop !== 'left')) {
+        if (object[prop] === prototype[prop]) {
           delete object[prop];
         }
         var isArray = Object.prototype.toString.call(object[prop]) === '[object Array]' &&

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -485,7 +485,9 @@
      */
     toObject: function(propertiesToInclude) {
       var o = extend(this.callSuper('toObject', ['sourcePath', 'pathOffset'].concat(propertiesToInclude)), {
-        path: this.path.map(function(item) { return item.slice(); })
+        path: this.path.map(function(item) { return item.slice(); }),
+        top: this.top,
+        left: this.left,
       });
       return o;
     },

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -343,7 +343,6 @@
     deepEqual(augmentedObjectRepr.transformMatrix, toObjectObj.transformMatrix);
     notEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);
     deepEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);
-
   });
 
   test('toDatalessObject', function() {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -102,9 +102,21 @@
     });
   });
 
+  asyncTest('toObject', function() {
+    makePathObject(function(path) {
+      path.top = fabric.Object.prototype.top;
+      path.left = fabric.Object.prototype.left;
+      path.includeDefaultValues = false;
+      var obj = path.toObject();
+      equal(obj.top, fabric.Object.prototype.top, 'top is available also when equal to prototype');
+      equal(obj.left, fabric.Object.prototype.left, 'left is available also when equal to prototype');
+      start();
+    });
+  });
+
   asyncTest('toSVG', function() {
     makePathObject(function(path) {
-      ok(typeof path.toObject == 'function');
+      ok(typeof path.toSVG == 'function');
       deepEqual(path.toSVG(), '<path d="M 100 100 L 300 100 L 200 300 z" style="stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;" transform="translate(200.5 200.5) translate(-200, -200) " stroke-linecap="round" />\n');
       start();
     });


### PR DESCRIPTION
close #3683 

Path objects with top and left not available in the constructor get theyr position parsed by the command path.

Top and left should be always in the object representation even if they are equal to prototypes values.