### PR TITLE
Do not fire selection changed if we are not editing

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -355,7 +355,7 @@
 
       this._tick();
       this.fire('editing:entered');
-
+      this._fireSelectionChanged();
       if (!this.canvas) {
         return this;
       }

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -153,8 +153,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.selectionStart = newSelection;
       this.selectionEnd = newSelection;
     }
-    this._fireSelectionChanged();
-    this._updateTextarea();
+    if (this.isEditing) {
+      this._fireSelectionChanged();
+      this._updateTextarea();
+    }     
   },
 
   /**

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -156,7 +156,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     if (this.isEditing) {
       this._fireSelectionChanged();
       this._updateTextarea();
-    }     
+    }
   },
 
   /**

--- a/test/unit/itext_key_behaviour.js
+++ b/test/unit/itext_key_behaviour.js
@@ -13,7 +13,8 @@
     iText.on('selection:changed', countSelectionChange);
 
     iText.enterEditing();
-    equal(selection, 0, 'should not fire on enter edit');
+    equal(selection, 1, 'will fire on enter edit since the cursor is changing for the first time');
+    selection = 0;
 
     iText.selectAll();
     equal(selection, 1, 'should fire once on selectAll');
@@ -144,7 +145,8 @@
     iText.on('selection:changed', countSelectionChange);
 
     iText.enterEditing();
-    equal(selection, 0, 'should not fire on enter edit');
+    equal(selection, 1, 'should fire on enter edit');
+    selection = 0;
 
     iText.selectAll();
     equal(selection, 1, 'should fire once on selectAll');


### PR DESCRIPTION
@stefanhayden  found out that the event selection changed is improperly fired every mouse down when the textbox is not editing.