### PR TITLE
fix for bluriness introduced in 1.7.3

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -872,8 +872,8 @@
           width = dim.x * zoomX,
           height = dim.y * zoomY;
       return {
-        width: Math.ceil(width) + 2,
-        height: Math.ceil(height) + 2,
+        width: width + 2,
+        height: height + 2,
         zoomX: zoomX,
         zoomY: zoomY
       };
@@ -897,8 +897,8 @@
           zoomX = dims.zoomX, zoomY = dims.zoomY;
 
       if (width !== this.cacheWidth || height !== this.cacheHeight) {
-        this._cacheCanvas.width = width;
-        this._cacheCanvas.height = height;
+        this._cacheCanvas.width = Math.ceil(width);
+        this._cacheCanvas.height = Math.ceil(height);
         this._cacheContext.translate(width / 2, height / 2);
         this._cacheContext.scale(zoomX, zoomY);
         this.cacheWidth = width;

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -403,9 +403,9 @@
      */
     _getCacheCanvasDimensions: function() {
       var dim = this.callSuper('_getCacheCanvasDimensions');
-      var fontSize = Math.ceil(this.fontSize) * 2;
-      dim.width += fontSize;
-      dim.height += fontSize;
+      var fontSize = this.fontSize * 2;
+      dim.width += fontSize * dim.zoomX;
+      dim.height += fontSize * dim.zoomY;
       return dim;
     },
 


### PR DESCRIPTION
Rounding the canvas to integer dimensions is a necessary step.
Translating to rounded values of the dimensions is wrong.

Need to fix the drawing of the cache since this may introduce some little problem in positioning.