### PR TITLE
Fix problem on fabric.Line controls and line.getWidth()

### DIFF
--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -167,10 +167,11 @@
         //  Line coords are distances from left-top of canvas to origin of line.
         //  To render line in a path-group, we need to translate them to
         //  distances from center of path-group to center of line.
-        var cp = this.getCenterPoint();
+        var cp = this.getCenterPoint(),
+            offset = this.strokeWidth / 2;
         ctx.translate(
-          cp.x - this.strokeWidth / 2,
-          cp.y - this.strokeWidth / 2
+          cp.x - (this.strokeLineCap === 'butt' && this.height === 0 ? 0 : offset),
+          cp.y - (this.strokeLineCap === 'butt' && this.width === 0 ? 0 : offset)
         );
       }
 
@@ -222,11 +223,13 @@
     _getNonTransformedDimensions: function() {
       var dim = this.callSuper('_getNonTransformedDimensions');
       if (this.strokeLineCap === 'butt') {
-        if (dim.x === 0) {
+        if (this.width === 0) {
           dim.y -= this.strokeWidth;
         }
+        if (this.height === 0) {
+          dim.x -= this.strokeWidth;
+        }
       }
-      dim.x = this.width;
       return dim;
     },
 
@@ -241,10 +244,7 @@
           y1 = (yMult * this.height * 0.5),
           x2 = (xMult * this.width * -0.5),
           y2 = (yMult * this.height * -0.5);
-      if (this.strokeLineCap === 'round') {
-        x1 = xMult * (this.width - this.strokeWidth) * 0.5;
-        x2 = xMult * (this.width - this.strokeWidth) * -0.5;
-      }
+
       return {
         x1: x1,
         x2: x2,

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -225,10 +225,8 @@
         if (dim.x === 0) {
           dim.y -= this.strokeWidth;
         }
-        if (dim.y === 0) {
-          dim.x -= this.strokeWidth;
-        }
       }
+      dim.x = this.width;
       return dim;
     },
 
@@ -243,7 +241,10 @@
           y1 = (yMult * this.height * 0.5),
           x2 = (xMult * this.width * -0.5),
           y2 = (yMult * this.height * -0.5);
-
+      if (this.strokeLineCap === 'round') {
+        x1 = xMult * (this.width - this.strokeWidth) * 0.5;
+        x2 = xMult * (this.width - this.strokeWidth) * -0.5;
+      }
       return {
         x1: x1,
         x2: x2,


### PR DESCRIPTION
There is a bug when creating a fabric.Line + strokeWidth.
- There is a padding in the control.
- getWidth returns width + strokeWidth.

[DEMO MASTER BRANCH](http://jsfiddle.net/vudduu/nj29m5qu/)
[DEMO WITH FIX](http://jsfiddle.net/vudduu/qehwu2mj/)