### PR TITLE
fix text coordinates on init

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -358,6 +358,7 @@
       this.callSuper('initialize', options);
       this.__skipDimension = false;
       this._initDimensions();
+      this.setCoords();
       this.setupState({ propertySet: '_dimensionAffectingProps' });
     },
 

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -2,8 +2,8 @@
 
   QUnit.module('fabric.Text');
 
-  function createTextObject() {
-    return new fabric.Text('x');
+  function createTextObject(text) {
+    return new fabric.Text(text || 'x');
   }
 
   var CHAR_WIDTH = 20;
@@ -139,6 +139,23 @@
     equal(text.getOpacity(), 0.123);
     equal(text.getFill(), 'red');
     equal(text.get('fontFamily'), 'blah');
+  });
+
+  test('get bounding rect after init', function() {
+    var string = 'Some long text, the quick brown fox jumps over the lazy dog etc... blah blah blah';
+    var text = new fabric.Text(string, {
+        left: 30,
+        top: 30,
+        fill: "#ffffff",
+        fontSize: 24,
+        fontWeight: 'normal',
+        fontFamily: "Arial",
+        originY: "bottom"
+    });
+    var br = text.getBoundingRect();
+    text.setCoords();
+    var br2 = text.getBoundingRect();
+    deepEqual(br, br2, 'text bounding box is the same before and after calling setCoords')
   });
 
   test('setShadow', function(){

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -144,18 +144,18 @@
   test('get bounding rect after init', function() {
     var string = 'Some long text, the quick brown fox jumps over the lazy dog etc... blah blah blah';
     var text = new fabric.Text(string, {
-        left: 30,
-        top: 30,
-        fill: "#ffffff",
-        fontSize: 24,
-        fontWeight: 'normal',
-        fontFamily: "Arial",
-        originY: "bottom"
+      left: 30,
+      top: 30,
+      fill: '#ffffff',
+      fontSize: 24,
+      fontWeight: 'normal',
+      fontFamily: 'Arial',
+      originY: 'bottom'
     });
     var br = text.getBoundingRect();
     text.setCoords();
     var br2 = text.getBoundingRect();
-    deepEqual(br, br2, 'text bounding box is the same before and after calling setCoords')
+    deepEqual(br, br2, 'text bounding box is the same before and after calling setCoords');
   });
 
   test('setShadow', function(){


### PR DESCRIPTION
Since initDimensions change the width, is better to call setCoords anyway after object initialization.
The latest initDimension called will probably change the width but will not call again setCoords after it.

closes #3719