### PR TITLE
remove unused "originalState" var

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -76,8 +76,6 @@
         this._objects[i].group = this;
       }
 
-      this.originalState = { };
-
       if (options.originX) {
         this.originX = options.originX;
       }


### PR DESCRIPTION
Var still present in the group class, but unused.