### PR TITLE
fixing callSuper

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -18,6 +18,7 @@
     onDeselect: function() {
       this.isEditing && this.exitEditing();
       this.selected = false;
+      this.callSuper('onDeselect');
     },
 
     /**

--- a/src/mixins/object_origin.mixin.js
+++ b/src/mixins/object_origin.mixin.js
@@ -250,6 +250,13 @@
      */
     _getLeftTopCoords: function() {
       return this.translateToOriginPoint(this.getCenterPoint(), 'left', 'top');
+    },
+
+    /**
+    * Callback; invoked right before object is about to go from active to inactive
+    */
+    onDeselect: function() {
+      /* NOOP */
     }
   });
 

--- a/src/util/lang_class.js
+++ b/src/util/lang_class.js
@@ -51,10 +51,27 @@
   function Subclass() { }
 
   function callSuper(methodName) {
-    var fn = this.constructor.superclass.prototype[methodName];
+    var parentMethod;
+
+    // climb prototype chain to find method not equal to callee's method
+    var currentContext = this;
+    while (currentContext.constructor.superclass) {
+      var superClassProto = currentContext.constructor.superclass.prototype;
+      var superClassMethod = superClassProto[methodName];
+      if (currentContext[methodName] !== superClassMethod) {
+        parentMethod = superClassMethod;
+        break;
+      }
+      currentContext = currentContext.constructor.superclass.prototype;
+    }
+
+    if (!parentMethod) {
+      return console.log('tried to callSuper ' + methodName + ', method not found in prototype chain', this);
+    }
+
     return (arguments.length > 1)
-      ? fn.apply(this, slice.call(arguments, 1))
-      : fn.call(this);
+      ? parentMethod.apply(this, slice.call(arguments, 1))
+      : parentMethod.call(this);
   }
 
   /**

--- a/src/util/lang_class.js
+++ b/src/util/lang_class.js
@@ -51,13 +51,12 @@
   function Subclass() { }
 
   function callSuper(methodName) {
-    var parentMethod;
+    var parentMethod = null,
+        currentContext = this;
 
     // climb prototype chain to find method not equal to callee's method
-    var currentContext = this;
     while (currentContext.constructor.superclass) {
-      var superClassProto = currentContext.constructor.superclass.prototype;
-      var superClassMethod = superClassProto[methodName];
+      var superClassMethod = currentContext.constructor.superclass.prototype[methodName];
       if (currentContext[methodName] !== superClassMethod) {
         parentMethod = superClassMethod;
         break;

--- a/src/util/lang_class.js
+++ b/src/util/lang_class.js
@@ -52,16 +52,16 @@
 
   function callSuper(methodName) {
     var parentMethod = null,
-        currentContext = this;
+        _this = this;
 
     // climb prototype chain to find method not equal to callee's method
-    while (currentContext.constructor.superclass) {
-      var superClassMethod = currentContext.constructor.superclass.prototype[methodName];
-      if (currentContext[methodName] !== superClassMethod) {
+    while (_this.constructor.superclass) {
+      var superClassMethod = _this.constructor.superclass.prototype[methodName];
+      if (_this[methodName] !== superClassMethod) {
         parentMethod = superClassMethod;
         break;
       }
-      currentContext = currentContext.constructor.superclass.prototype;
+      _this = _this.constructor.superclass.prototype;
     }
 
     if (!parentMethod) {


### PR DESCRIPTION
At present callSuper can go into an infinite loop if it is called above the bottom level in the prototype chain, this fixes that.

This fix allows fixing the IText class to run `callSuper('onDeselect')`.  

Also placing an empty function on the `fabric.Object` class in case there is no `onDeselect` defined on the parent.

thank you for your help @asturur 