### PR TITLE
Update _fireOverOutEvents to pass event object

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1136,16 +1136,16 @@
         if (this._hoveredTarget !== target) {
           if (this._hoveredTarget) {
             this.fire('mouse:out', { target: this._hoveredTarget, e: e });
-            this._hoveredTarget.fire('mouseout');
+            this._hoveredTarget.fire('mouseout', { e: e });
           }
           this.fire('mouse:over', { target: target, e: e });
-          target.fire('mouseover');
+          target.fire('mouseover', { e: e });
           this._hoveredTarget = target;
         }
       }
       else if (this._hoveredTarget) {
         this.fire('mouse:out', { target: this._hoveredTarget, e: e });
-        this._hoveredTarget.fire('mouseout');
+        this._hoveredTarget.fire('mouseout', { e: e });
         this._hoveredTarget = null;
       }
     },


### PR DESCRIPTION
I encountered a scenario where we were listening for `mouseout` and calling `_isObjectMoved` expecting an event object to be passed from the `mouseout` listener, however the object was not passed from `_fireOverOutEvents`. Normally this would not be an issue as `_isObjectMoved()` -> `getPointer()` checks for `fabric.window.event` and uses that if `event` is undefined, but this produces an error in Firefox as the `window.event` property is not implemented (https://developer.mozilla.org/en-US/docs/Web/API/Window/event).

To resolve this I am proposing that `_fireOverOutEvents` pass along the event object to the target so that it can be passed along to `isObjectMoved()` if necessary.