### PR TITLE
Cursor disappears after text entry

### DIFF
--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -89,7 +89,7 @@
       if (this.__skipDimension) {
         return;
       }
-      this.abortCursorAnimation();
+      this.initDelayedCursor();
       this.clearContextTop();
       this._clearCache();
       // clear dynamicMinWidth as it will be different after we re-wrap line


### PR DESCRIPTION
calling `this.abortCursorAnimation()` means the cursor does not get restarted. `this.initDelayedCursor();` both aborts and starts it again.