### PR TITLE
Fix rendering justified text with line breaks and last line

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -792,15 +792,15 @@
      * @param {Number} left
      * @param {Number} top
      * @param {Number} lineIndex
-     * @param {Boolean} withBreak Detects if line contains line break at the end or it's the last line in text
+     * @param {Boolean} isLastLine Detects if the line is last in the text
      */
-    _renderTextLine: function(method, ctx, line, left, top, lineIndex, withBreak) {
+    _renderTextLine: function(method, ctx, line, left, top, lineIndex, isLastLine) {
       // to "cancel" this.fontSize subtraction in fabric.Text#_renderTextLine
       // the adding 0.03 is just to align text with itext by overlap test
       if (!this.isEmptyStyles()) {
         top += this.fontSize * (this._fontSizeFraction + 0.03);
       }
-      this.callSuper('_renderTextLine', method, ctx, line, left, top, lineIndex, withBreak);
+      this.callSuper('_renderTextLine', method, ctx, line, left, top, lineIndex, isLastLine);
     },
 
     /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -264,7 +264,7 @@
       }
 
       var loc = this.get2DCursorLocation(startIndex),
-        style = this._getStyleDeclaration(loc.lineIndex, loc.charIndex);
+          style = this._getStyleDeclaration(loc.lineIndex, loc.charIndex);
 
       return style || {};
     },
@@ -370,7 +370,7 @@
         return;
       }
       var chars = this.text.split(''),
-        boundaries, ctx;
+          boundaries, ctx;
       if (this.canvas && this.canvas.contextTop) {
         ctx = this.canvas.contextTop;
         ctx.save();
@@ -479,10 +479,10 @@
       // leftOffset/topOffset are offset from that left/top point of a text box
 
       var left = Math.round(this._getLeftOffset()),
-        top = this._getTopOffset(),
+          top = this._getTopOffset(),
 
-        offsets = this._getCursorBoundariesOffsets(
-          chars, typeOfBoundaries);
+          offsets = this._getCursorBoundariesOffsets(
+                      chars, typeOfBoundaries);
 
       return {
         left: left,
@@ -500,11 +500,11 @@
         return this.cursorOffsetCache;
       }
       var lineLeftOffset = 0,
-        lineIndex = 0,
-        charIndex = 0,
-        topOffset = 0,
-        leftOffset = 0,
-        boundaries;
+          lineIndex = 0,
+          charIndex = 0,
+          topOffset = 0,
+          leftOffset = 0,
+          boundaries;
 
       for (var i = 0; i < this.selectionStart; i++) {
         if (chars[i] === '\n') {
@@ -545,12 +545,12 @@
     renderCursor: function(boundaries, ctx) {
 
       var cursorLocation = this.get2DCursorLocation(),
-        lineIndex = cursorLocation.lineIndex,
-        charIndex = cursorLocation.charIndex,
-        charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
-        leftOffset = boundaries.leftOffset,
-        multiplier = this.scaleX * this.canvas.getZoom(),
-        cursorWidth = this.cursorWidth / multiplier;
+          lineIndex = cursorLocation.lineIndex,
+          charIndex = cursorLocation.charIndex,
+          charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
+          leftOffset = boundaries.leftOffset,
+          multiplier = this.scaleX * this.canvas.getZoom(),
+          cursorWidth = this.cursorWidth / multiplier;
 
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
       ctx.globalAlpha = this.__isMousedown ? 1 : this._currentCursorOpacity;
@@ -573,13 +573,13 @@
       ctx.fillStyle = this.selectionColor;
 
       var start = this.get2DCursorLocation(this.selectionStart),
-        end = this.get2DCursorLocation(this.selectionEnd),
-        startLine = start.lineIndex,
-        endLine = end.lineIndex;
+          end = this.get2DCursorLocation(this.selectionEnd),
+          startLine = start.lineIndex,
+          endLine = end.lineIndex;
       for (var i = startLine; i <= endLine; i++) {
         var lineOffset = this._getLineLeftOffset(this._getLineWidth(ctx, i)) || 0,
-          lineHeight = this._getHeightOfLine(this.ctx, i),
-          realLineHeight = 0, boxWidth = 0, line = this._textLines[i];
+            lineHeight = this._getHeightOfLine(this.ctx, i),
+            realLineHeight = 0, boxWidth = 0, line = this._textLines[i];
 
         if (i === startLine) {
           for (var j = 0, len = line.length; j < len; j++) {
@@ -639,9 +639,9 @@
 
       // set proper line offset
       var lineHeight = this._getHeightOfLine(ctx, lineIndex),
-        prevStyle,
-        thisStyle,
-        charsToRender = '';
+          prevStyle,
+          thisStyle,
+          charsToRender = '';
 
       ctx.save();
       top -= lineHeight / this.lineHeight * this._fontSizeFraction;
@@ -690,8 +690,8 @@
      */
     _renderChar: function(method, ctx, lineIndex, i, _char, left, top, lineHeight) {
       var charWidth, charHeight, shouldFill, shouldStroke,
-        decl = this._getStyleDeclaration(lineIndex, i),
-        offset, textDecoration, chars, additionalSpace, _charWidth;
+          decl = this._getStyleDeclaration(lineIndex, i),
+          offset, textDecoration, chars, additionalSpace, _charWidth;
 
       if (decl) {
         charHeight = this._getHeightOfChar(ctx, _char, lineIndex, i);
@@ -747,14 +747,14 @@
      */
     _hasStyleChanged: function(prevStyle, thisStyle) {
       return (prevStyle.fill !== thisStyle.fill ||
-        prevStyle.fontSize !== thisStyle.fontSize ||
-        prevStyle.textBackgroundColor !== thisStyle.textBackgroundColor ||
-        prevStyle.textDecoration !== thisStyle.textDecoration ||
-        prevStyle.fontFamily !== thisStyle.fontFamily ||
-        prevStyle.fontWeight !== thisStyle.fontWeight ||
-        prevStyle.fontStyle !== thisStyle.fontStyle ||
-        prevStyle.stroke !== thisStyle.stroke ||
-        prevStyle.strokeWidth !== thisStyle.strokeWidth
+              prevStyle.fontSize !== thisStyle.fontSize ||
+              prevStyle.textBackgroundColor !== thisStyle.textBackgroundColor ||
+              prevStyle.textDecoration !== thisStyle.textDecoration ||
+              prevStyle.fontFamily !== thisStyle.fontFamily ||
+              prevStyle.fontWeight !== thisStyle.fontWeight ||
+              prevStyle.fontStyle !== thisStyle.fontStyle ||
+              prevStyle.stroke !== thisStyle.stroke ||
+              prevStyle.strokeWidth !== thisStyle.strokeWidth
       );
     },
 
@@ -769,12 +769,12 @@
       }
 
       var decorationWeight = charHeight / 15,
-        positions = {
-          underline: top + charHeight / 10,
-          'line-through': top - charHeight * (this._fontSizeFraction + this._fontSizeMult - 1) + decorationWeight,
-          overline: top - (this._fontSizeMult - this._fontSizeFraction) * charHeight
-        },
-        decorations = ['underline', 'line-through', 'overline'], i, decoration;
+          positions = {
+            underline: top + charHeight / 10,
+            'line-through': top - charHeight * (this._fontSizeFraction + this._fontSizeMult - 1) + decorationWeight,
+            overline: top - (this._fontSizeMult - this._fontSizeFraction) * charHeight
+          },
+          decorations = ['underline', 'line-through', 'overline'], i, decoration;
 
       for (i = 0; i < decorations.length; i++) {
         decoration = decorations[i];
@@ -821,12 +821,12 @@
       this.callSuper('_renderTextLinesBackground', ctx);
 
       var lineTopOffset = 0, heightOfLine,
-        lineWidth, lineLeftOffset,
-        leftOffset = this._getLeftOffset(),
-        topOffset = this._getTopOffset(),
-        colorCache = '',
-        line, _char, style, leftCache,
-        topCache, widthCache, heightCache;
+          lineWidth, lineLeftOffset,
+          leftOffset = this._getLeftOffset(),
+          topOffset = this._getTopOffset(),
+          colorCache = '',
+          line, _char, style, leftCache,
+          topCache, widthCache, heightCache;
       ctx.save();
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         heightOfLine = this._getHeightOfLine(ctx, i);
@@ -884,9 +884,9 @@
      */
     _getCacheProp: function(_char, styleDeclaration) {
       return _char +
-        styleDeclaration.fontSize +
-        styleDeclaration.fontWeight +
-        styleDeclaration.fontStyle;
+             styleDeclaration.fontSize +
+             styleDeclaration.fontWeight +
+             styleDeclaration.fontStyle;
     },
 
     /**
@@ -911,8 +911,8 @@
      */
     _applyCharStylesGetWidth: function(ctx, _char, lineIndex, charIndex, decl) {
       var charDecl = decl || this._getStyleDeclaration(lineIndex, charIndex),
-        styleDeclaration = clone(charDecl),
-        width, cacheProp, charWidthsCache;
+          styleDeclaration = clone(charDecl),
+          width, cacheProp, charWidthsCache;
 
       this._applyFontStyles(styleDeclaration);
       charWidthsCache = this._getFontCache(styleDeclaration.fontFamily);
@@ -1110,10 +1110,10 @@
         return this.__widthOfSpace[lineIndex];
       }
       var line = this._textLines[lineIndex],
-        wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
-        widthDiff = this.width - wordsWidth,
-        numSpaces = line.length - line.replace(this._reSpacesAndTabs, '').length,
-        width = Math.max(widthDiff / numSpaces, ctx.measureText(' ').width);
+          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
+          widthDiff = this.width - wordsWidth,
+          numSpaces = line.length - line.replace(this._reSpacesAndTabs, '').length,
+          width = Math.max(widthDiff / numSpaces, ctx.measureText(' ').width);
       this.__widthOfSpace[lineIndex] = width;
       return width;
     },
@@ -1149,7 +1149,7 @@
       }
 
       var line = this._textLines[lineIndex],
-        maxHeight = this._getHeightOfChar(ctx, lineIndex, 0);
+          maxHeight = this._getHeightOfChar(ctx, lineIndex, 0);
 
       for (var i = 1, len = line.length; i < len; i++) {
         var currentCharHeight = this._getHeightOfChar(ctx, lineIndex, i);

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -264,7 +264,7 @@
       }
 
       var loc = this.get2DCursorLocation(startIndex),
-          style = this._getStyleDeclaration(loc.lineIndex, loc.charIndex);
+        style = this._getStyleDeclaration(loc.lineIndex, loc.charIndex);
 
       return style || {};
     },
@@ -370,7 +370,7 @@
         return;
       }
       var chars = this.text.split(''),
-          boundaries, ctx;
+        boundaries, ctx;
       if (this.canvas && this.canvas.contextTop) {
         ctx = this.canvas.contextTop;
         ctx.save();
@@ -479,10 +479,10 @@
       // leftOffset/topOffset are offset from that left/top point of a text box
 
       var left = Math.round(this._getLeftOffset()),
-          top = this._getTopOffset(),
+        top = this._getTopOffset(),
 
-          offsets = this._getCursorBoundariesOffsets(
-                      chars, typeOfBoundaries);
+        offsets = this._getCursorBoundariesOffsets(
+          chars, typeOfBoundaries);
 
       return {
         left: left,
@@ -500,11 +500,11 @@
         return this.cursorOffsetCache;
       }
       var lineLeftOffset = 0,
-          lineIndex = 0,
-          charIndex = 0,
-          topOffset = 0,
-          leftOffset = 0,
-          boundaries;
+        lineIndex = 0,
+        charIndex = 0,
+        topOffset = 0,
+        leftOffset = 0,
+        boundaries;
 
       for (var i = 0; i < this.selectionStart; i++) {
         if (chars[i] === '\n') {
@@ -545,12 +545,12 @@
     renderCursor: function(boundaries, ctx) {
 
       var cursorLocation = this.get2DCursorLocation(),
-          lineIndex = cursorLocation.lineIndex,
-          charIndex = cursorLocation.charIndex,
-          charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
-          leftOffset = boundaries.leftOffset,
-          multiplier = this.scaleX * this.canvas.getZoom(),
-          cursorWidth = this.cursorWidth / multiplier;
+        lineIndex = cursorLocation.lineIndex,
+        charIndex = cursorLocation.charIndex,
+        charHeight = this.getCurrentCharFontSize(lineIndex, charIndex),
+        leftOffset = boundaries.leftOffset,
+        multiplier = this.scaleX * this.canvas.getZoom(),
+        cursorWidth = this.cursorWidth / multiplier;
 
       ctx.fillStyle = this.getCurrentCharColor(lineIndex, charIndex);
       ctx.globalAlpha = this.__isMousedown ? 1 : this._currentCursorOpacity;
@@ -573,13 +573,13 @@
       ctx.fillStyle = this.selectionColor;
 
       var start = this.get2DCursorLocation(this.selectionStart),
-          end = this.get2DCursorLocation(this.selectionEnd),
-          startLine = start.lineIndex,
-          endLine = end.lineIndex;
+        end = this.get2DCursorLocation(this.selectionEnd),
+        startLine = start.lineIndex,
+        endLine = end.lineIndex;
       for (var i = startLine; i <= endLine; i++) {
         var lineOffset = this._getLineLeftOffset(this._getLineWidth(ctx, i)) || 0,
-            lineHeight = this._getHeightOfLine(this.ctx, i),
-            realLineHeight = 0, boxWidth = 0, line = this._textLines[i];
+          lineHeight = this._getHeightOfLine(this.ctx, i),
+          realLineHeight = 0, boxWidth = 0, line = this._textLines[i];
 
         if (i === startLine) {
           for (var j = 0, len = line.length; j < len; j++) {
@@ -639,9 +639,9 @@
 
       // set proper line offset
       var lineHeight = this._getHeightOfLine(ctx, lineIndex),
-          prevStyle,
-          thisStyle,
-          charsToRender = '';
+        prevStyle,
+        thisStyle,
+        charsToRender = '';
 
       ctx.save();
       top -= lineHeight / this.lineHeight * this._fontSizeFraction;
@@ -690,8 +690,8 @@
      */
     _renderChar: function(method, ctx, lineIndex, i, _char, left, top, lineHeight) {
       var charWidth, charHeight, shouldFill, shouldStroke,
-          decl = this._getStyleDeclaration(lineIndex, i),
-          offset, textDecoration, chars, additionalSpace, _charWidth;
+        decl = this._getStyleDeclaration(lineIndex, i),
+        offset, textDecoration, chars, additionalSpace, _charWidth;
 
       if (decl) {
         charHeight = this._getHeightOfChar(ctx, _char, lineIndex, i);
@@ -747,14 +747,14 @@
      */
     _hasStyleChanged: function(prevStyle, thisStyle) {
       return (prevStyle.fill !== thisStyle.fill ||
-              prevStyle.fontSize !== thisStyle.fontSize ||
-              prevStyle.textBackgroundColor !== thisStyle.textBackgroundColor ||
-              prevStyle.textDecoration !== thisStyle.textDecoration ||
-              prevStyle.fontFamily !== thisStyle.fontFamily ||
-              prevStyle.fontWeight !== thisStyle.fontWeight ||
-              prevStyle.fontStyle !== thisStyle.fontStyle ||
-              prevStyle.stroke !== thisStyle.stroke ||
-              prevStyle.strokeWidth !== thisStyle.strokeWidth
+        prevStyle.fontSize !== thisStyle.fontSize ||
+        prevStyle.textBackgroundColor !== thisStyle.textBackgroundColor ||
+        prevStyle.textDecoration !== thisStyle.textDecoration ||
+        prevStyle.fontFamily !== thisStyle.fontFamily ||
+        prevStyle.fontWeight !== thisStyle.fontWeight ||
+        prevStyle.fontStyle !== thisStyle.fontStyle ||
+        prevStyle.stroke !== thisStyle.stroke ||
+        prevStyle.strokeWidth !== thisStyle.strokeWidth
       );
     },
 
@@ -769,12 +769,12 @@
       }
 
       var decorationWeight = charHeight / 15,
-          positions = {
-            underline: top + charHeight / 10,
-            'line-through': top - charHeight * (this._fontSizeFraction + this._fontSizeMult - 1) + decorationWeight,
-            overline: top - (this._fontSizeMult - this._fontSizeFraction) * charHeight
-          },
-          decorations = ['underline', 'line-through', 'overline'], i, decoration;
+        positions = {
+          underline: top + charHeight / 10,
+          'line-through': top - charHeight * (this._fontSizeFraction + this._fontSizeMult - 1) + decorationWeight,
+          overline: top - (this._fontSizeMult - this._fontSizeFraction) * charHeight
+        },
+        decorations = ['underline', 'line-through', 'overline'], i, decoration;
 
       for (i = 0; i < decorations.length; i++) {
         decoration = decorations[i];
@@ -792,14 +792,15 @@
      * @param {Number} left
      * @param {Number} top
      * @param {Number} lineIndex
+     * @param {Boolean} withBreak Detects if line contains line break at the end or it's the last line in text
      */
-    _renderTextLine: function(method, ctx, line, left, top, lineIndex) {
+    _renderTextLine: function(method, ctx, line, left, top, lineIndex, withBreak) {
       // to "cancel" this.fontSize subtraction in fabric.Text#_renderTextLine
       // the adding 0.03 is just to align text with itext by overlap test
       if (!this.isEmptyStyles()) {
         top += this.fontSize * (this._fontSizeFraction + 0.03);
       }
-      this.callSuper('_renderTextLine', method, ctx, line, left, top, lineIndex);
+      this.callSuper('_renderTextLine', method, ctx, line, left, top, lineIndex, withBreak);
     },
 
     /**
@@ -820,12 +821,12 @@
       this.callSuper('_renderTextLinesBackground', ctx);
 
       var lineTopOffset = 0, heightOfLine,
-          lineWidth, lineLeftOffset,
-          leftOffset = this._getLeftOffset(),
-          topOffset = this._getTopOffset(),
-          colorCache = '',
-          line, _char, style, leftCache,
-          topCache, widthCache, heightCache;
+        lineWidth, lineLeftOffset,
+        leftOffset = this._getLeftOffset(),
+        topOffset = this._getTopOffset(),
+        colorCache = '',
+        line, _char, style, leftCache,
+        topCache, widthCache, heightCache;
       ctx.save();
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         heightOfLine = this._getHeightOfLine(ctx, i);
@@ -883,9 +884,9 @@
      */
     _getCacheProp: function(_char, styleDeclaration) {
       return _char +
-             styleDeclaration.fontSize +
-             styleDeclaration.fontWeight +
-             styleDeclaration.fontStyle;
+        styleDeclaration.fontSize +
+        styleDeclaration.fontWeight +
+        styleDeclaration.fontStyle;
     },
 
     /**
@@ -910,8 +911,8 @@
      */
     _applyCharStylesGetWidth: function(ctx, _char, lineIndex, charIndex, decl) {
       var charDecl = decl || this._getStyleDeclaration(lineIndex, charIndex),
-          styleDeclaration = clone(charDecl),
-          width, cacheProp, charWidthsCache;
+        styleDeclaration = clone(charDecl),
+        width, cacheProp, charWidthsCache;
 
       this._applyFontStyles(styleDeclaration);
       charWidthsCache = this._getFontCache(styleDeclaration.fontFamily);
@@ -1109,10 +1110,10 @@
         return this.__widthOfSpace[lineIndex];
       }
       var line = this._textLines[lineIndex],
-          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
-          widthDiff = this.width - wordsWidth,
-          numSpaces = line.length - line.replace(this._reSpacesAndTabs, '').length,
-          width = Math.max(widthDiff / numSpaces, ctx.measureText(' ').width);
+        wordsWidth = this._getWidthOfWords(ctx, line, lineIndex, 0),
+        widthDiff = this.width - wordsWidth,
+        numSpaces = line.length - line.replace(this._reSpacesAndTabs, '').length,
+        width = Math.max(widthDiff / numSpaces, ctx.measureText(' ').width);
       this.__widthOfSpace[lineIndex] = width;
       return width;
     },
@@ -1148,7 +1149,7 @@
       }
 
       var line = this._textLines[lineIndex],
-          maxHeight = this._getHeightOfChar(ctx, lineIndex, 0);
+        maxHeight = this._getHeightOfChar(ctx, lineIndex, 0);
 
       for (var i = 1, len = line.length; i < len; i++) {
         var currentCharHeight = this._getHeightOfChar(ctx, lineIndex, i);

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -510,15 +510,15 @@
      * @param {Number} left Left position of text
      * @param {Number} top Top position of text
      * @param {Number} lineIndex Index of a line in a text
-     * @param {Boolean} withBreak Detects if line contains line break at the end or it's the last line in text
+     * @param {Boolean} isLastLine Detects if the line is last in the text
      */
-    _renderTextLine: function(method, ctx, line, left, top, lineIndex, withBreak) {
+    _renderTextLine: function(method, ctx, line, left, top, lineIndex, isLastLine) {
       // lift the line by quarter of fontSize
       top -= this.fontSize * this._fontSizeFraction;
 
       // short-circuit
       var lineWidth = this._getLineWidth(ctx, lineIndex);
-      if (this.textAlign !== 'justify' || this.width < lineWidth || withBreak) {
+      if (this.textAlign !== 'justify' || this.width < lineWidth || isLastLine) {
         this._renderChars(method, ctx, line, left, top, lineIndex);
         return;
       }
@@ -590,14 +590,12 @@
 
       var lineHeights = 0, left = this._getLeftOffset(), top = this._getTopOffset();
 
-      var lineIndexesWithBreak = this._getLineIndexesWithBreak();
-
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         var heightOfLine = this._getHeightOfLine(ctx, i),
             maxHeight = heightOfLine / this.lineHeight,
             lineWidth = this._getLineWidth(ctx, i),
             leftOffset = this._getLineLeftOffset(lineWidth),
-            withBreak = lineIndexesWithBreak.indexOf(i) > -1 || i === len - 1;
+            isLastLine = i === len - 1;
         this._renderTextLine(
           method,
           ctx,
@@ -605,7 +603,7 @@
           left + leftOffset,
           top + lineHeights + maxHeight,
           i,
-          withBreak
+          isLastLine
         );
         lineHeights += heightOfLine;
       }
@@ -1105,33 +1103,6 @@
      */
     complexity: function() {
       return 1;
-    },
-
-    /**
-     * Returns array of line indexes where line break at the end.
-     *
-     * @return {Array} The array of line indexes with line break at the end.
-     * @private
-     */
-    _getLineIndexesWithBreak: function() {
-      var splitLines = this.text.split(this._reNewline);
-      if (splitLines.length < 2) {
-        return [];
-      }
-      var i = 0;
-      var result = [];
-      for (var sl = 0; sl < splitLines.length; sl++) {
-        var currentSplitLineLength = splitLines[sl].length;
-        var compiledLine = '';
-        for (i; i < this._textLines.length; i++) {
-          compiledLine += this._textLines[i];
-          if (compiledLine.length > currentSplitLineLength) {
-            result.push(i - 1);
-            break;
-          }
-        }
-      }
-      return result;
     }
   });
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -3,9 +3,9 @@
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { }),
-    toFixed = fabric.util.toFixed,
-    NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
-    MIN_TEXT_WIDTH = 2;
+      toFixed = fabric.util.toFixed,
+      NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
+      MIN_TEXT_WIDTH = 2;
 
   if (fabric.Text) {
     fabric.warn('fabric.Text is already defined');
@@ -480,7 +480,7 @@
       var shortM = method.slice(0, -4), _char, width;
       if (this[shortM].toLive) {
         var offsetX = -this.width / 2 + this[shortM].offsetX || 0,
-          offsetY = -this.height / 2 + this[shortM].offsetY || 0;
+            offsetY = -this.height / 2 + this[shortM].offsetY || 0;
         ctx.save();
         ctx.translate(offsetX, offsetY);
         left -= offsetX;
@@ -525,12 +525,12 @@
 
       // stretch the line
       var words = line.split(/\s+/),
-        charOffset = 0,
-        wordsWidth = this._getWidthOfWords(ctx, words.join(' '), lineIndex, 0),
-        widthDiff = this.width - wordsWidth,
-        numSpaces = words.length - 1,
-        spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
-        leftOffset = 0, word;
+          charOffset = 0,
+          wordsWidth = this._getWidthOfWords(ctx, words.join(' '), lineIndex, 0),
+          widthDiff = this.width - wordsWidth,
+          numSpaces = words.length - 1,
+          spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
+          leftOffset = 0, word;
 
       for (var i = 0, len = words.length; i < len; i++) {
         while (line[charOffset] === ' ' && charOffset < line.length) {
@@ -594,10 +594,10 @@
 
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         var heightOfLine = this._getHeightOfLine(ctx, i),
-          maxHeight = heightOfLine / this.lineHeight,
-          lineWidth = this._getLineWidth(ctx, i),
-          leftOffset = this._getLineLeftOffset(lineWidth),
-          withBreak = lineIndexesWithBreak.indexOf(i) > -1 || i === len - 1;
+            maxHeight = heightOfLine / this.lineHeight,
+            lineWidth = this._getLineWidth(ctx, i),
+            leftOffset = this._getLineLeftOffset(lineWidth),
+            withBreak = lineIndexesWithBreak.indexOf(i) > -1 || i === len - 1;
         this._renderTextLine(
           method,
           ctx,
@@ -669,7 +669,7 @@
         return;
       }
       var lineTopOffset = 0, heightOfLine,
-        lineWidth, lineLeftOffset, originalFill = ctx.fillStyle;
+          lineWidth, lineLeftOffset, originalFill = ctx.fillStyle;
 
       ctx.fillStyle = this.textBackgroundColor;
       for (var i = 0, len = this._textLines.length; i < len; i++) {
@@ -773,8 +773,8 @@
      */
     _measureLine: function(ctx, lineIndex) {
       var line = this._textLines[lineIndex],
-        width = ctx.measureText(line).width,
-        additionalSpace = 0, charCount, finalWidth;
+          width = ctx.measureText(line).width,
+          additionalSpace = 0, charCount, finalWidth;
       if (this.charSpacing !== 0) {
         charCount = line.split('').length;
         additionalSpace = (charCount - 1) * this._getWidthOfCharSpacing();
@@ -792,12 +792,12 @@
         return;
       }
       var halfOfVerticalBox = this.height / 2,
-        _this = this, offsets = [];
+          _this = this, offsets = [];
 
       /** @ignore */
       function renderLinesAtOffset(offsets) {
         var i, lineHeight = 0, len, j, oLen, lineWidth,
-          lineLeftOffset, heightOfLine;
+            lineLeftOffset, heightOfLine;
 
         for (i = 0, len = _this._textLines.length; i < len; i++) {
 
@@ -904,8 +904,8 @@
         this.ctx = fabric.util.createCanvasElement().getContext('2d');
       }
       var markup = this._createBaseSVGMarkup(),
-        offsets = this._getSVGLeftTopOffsets(this.ctx),
-        textAndBg = this._getSVGTextAndBg(offsets.textTop, offsets.textLeft);
+          offsets = this._getSVGLeftTopOffsets(this.ctx),
+          textAndBg = this._getSVGTextAndBg(offsets.textTop, offsets.textLeft);
       this._wrapSVGTextAndBg(markup, textAndBg);
 
       return reviver ? reviver(markup.join('')) : markup.join('');
@@ -916,8 +916,8 @@
      */
     _getSVGLeftTopOffsets: function(ctx) {
       var lineTop = this._getHeightOfLine(ctx, 0),
-        textLeft = -this.width / 2,
-        textTop = 0;
+          textLeft = -this.width / 2,
+          textTop = 0;
 
       return {
         textLeft: textLeft + (this.group && this.group.type === 'path-group' ? this.left : 0),
@@ -931,21 +931,21 @@
      */
     _wrapSVGTextAndBg: function(markup, textAndBg) {
       var noShadow = true, filter = this.getSvgFilter(),
-        style = filter === '' ? '' : ' style="' + filter + '"';
+          style = filter === '' ? '' : ' style="' + filter + '"';
 
       markup.push(
         '\t<g ', this.getSvgId(), 'transform="', this.getSvgTransform(), this.getSvgTransformMatrix(), '"',
-        style, '>\n',
-        textAndBg.textBgRects.join(''),
-        '\t\t<text ',
-        (this.fontFamily ? 'font-family="' + this.fontFamily.replace(/"/g, '\'') + '" ' : ''),
-        (this.fontSize ? 'font-size="' + this.fontSize + '" ' : ''),
-        (this.fontStyle ? 'font-style="' + this.fontStyle + '" ' : ''),
-        (this.fontWeight ? 'font-weight="' + this.fontWeight + '" ' : ''),
-        (this.textDecoration ? 'text-decoration="' + this.textDecoration + '" ' : ''),
-        'style="', this.getSvgStyles(noShadow), '" >\n',
-        textAndBg.textSpans.join(''),
-        '\t\t</text>\n',
+          style, '>\n',
+          textAndBg.textBgRects.join(''),
+          '\t\t<text ',
+            (this.fontFamily ? 'font-family="' + this.fontFamily.replace(/"/g, '\'') + '" ' : ''),
+            (this.fontSize ? 'font-size="' + this.fontSize + '" ' : ''),
+            (this.fontStyle ? 'font-style="' + this.fontStyle + '" ' : ''),
+            (this.fontWeight ? 'font-weight="' + this.fontWeight + '" ' : ''),
+            (this.textDecoration ? 'text-decoration="' + this.textDecoration + '" ' : ''),
+            'style="', this.getSvgStyles(noShadow), '" >\n',
+            textAndBg.textSpans.join(''),
+          '\t\t</text>\n',
         '\t</g>\n'
       );
     },
@@ -958,8 +958,8 @@
      */
     _getSVGTextAndBg: function(textTopOffset, textLeftOffset) {
       var textSpans = [],
-        textBgRects = [],
-        height = 0;
+          textBgRects = [],
+          height = 0;
       // bounding-box background
       this._setSVGBg(textBgRects);
 
@@ -988,14 +988,14 @@
       }
       textSpans.push(
         '\t\t\t<tspan x="',
-        toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
-        'y="',
-        toFixed(yPos, NUM_FRACTION_DIGITS),
-        '" ',
-        // doing this on <tspan> elements since setting opacity
-        // on containing <text> one doesn't work in Illustrator
-        this._getFillAttributes(this.fill), '>',
-        fabric.util.string.escapeXml(this._textLines[i]),
+          toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS), '" ',
+          'y="',
+          toFixed(yPos, NUM_FRACTION_DIGITS),
+          '" ',
+          // doing this on <tspan> elements since setting opacity
+          // on containing <text> one doesn't work in Illustrator
+          this._getFillAttributes(this.fill), '>',
+          fabric.util.string.escapeXml(this._textLines[i]),
         '</tspan>\n'
       );
     },
@@ -1006,13 +1006,13 @@
       this._setTextStyles(ctx);
 
       var line = this._textLines[i],
-        words = line.split(/\s+/),
-        wordsWidth = this._getWidthOfWords(ctx, words.join('')),
-        widthDiff = this.width - wordsWidth,
-        numSpaces = words.length - 1,
-        spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
-        word, attributes = this._getFillAttributes(this.fill),
-        len;
+          words = line.split(/\s+/),
+          wordsWidth = this._getWidthOfWords(ctx, words.join('')),
+          widthDiff = this.width - wordsWidth,
+          numSpaces = words.length - 1,
+          spaceWidth = numSpaces > 0 ? widthDiff / numSpaces : 0,
+          word, attributes = this._getFillAttributes(this.fill),
+          len;
 
       textLeftOffset += this._getLineLeftOffset(this._getLineWidth(ctx, i));
 
@@ -1020,14 +1020,14 @@
         word = words[i];
         textSpans.push(
           '\t\t\t<tspan x="',
-          toFixed(textLeftOffset, NUM_FRACTION_DIGITS), '" ',
-          'y="',
-          toFixed(yPos, NUM_FRACTION_DIGITS),
-          '" ',
-          // doing this on <tspan> elements since setting opacity
-          // on containing <text> one doesn't work in Illustrator
-          attributes, '>',
-          fabric.util.string.escapeXml(word),
+            toFixed(textLeftOffset, NUM_FRACTION_DIGITS), '" ',
+            'y="',
+            toFixed(yPos, NUM_FRACTION_DIGITS),
+            '" ',
+            // doing this on <tspan> elements since setting opacity
+            // on containing <text> one doesn't work in Illustrator
+            attributes, '>',
+            fabric.util.string.escapeXml(word),
           '</tspan>\n'
         );
         textLeftOffset += this._getWidthOfWords(ctx, word) + spaceWidth;
@@ -1037,15 +1037,15 @@
     _setSVGTextLineBg: function(textBgRects, i, textLeftOffset, textTopOffset, height) {
       textBgRects.push(
         '\t\t<rect ',
-        this._getFillAttributes(this.textBackgroundColor),
-        ' x="',
-        toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS),
-        '" y="',
-        toFixed(height - this.height / 2, NUM_FRACTION_DIGITS),
-        '" width="',
-        toFixed(this._getLineWidth(this.ctx, i), NUM_FRACTION_DIGITS),
-        '" height="',
-        toFixed(this._getHeightOfLine(this.ctx, i) / this.lineHeight, NUM_FRACTION_DIGITS),
+          this._getFillAttributes(this.textBackgroundColor),
+          ' x="',
+          toFixed(textLeftOffset + this._getLineLeftOffset(this._getLineWidth(this.ctx, i)), NUM_FRACTION_DIGITS),
+          '" y="',
+          toFixed(height - this.height / 2, NUM_FRACTION_DIGITS),
+          '" width="',
+          toFixed(this._getLineWidth(this.ctx, i), NUM_FRACTION_DIGITS),
+          '" height="',
+          toFixed(this._getHeightOfLine(this.ctx, i) / this.lineHeight, NUM_FRACTION_DIGITS),
         '"></rect>\n');
     },
 
@@ -1053,15 +1053,15 @@
       if (this.backgroundColor) {
         textBgRects.push(
           '\t\t<rect ',
-          this._getFillAttributes(this.backgroundColor),
-          ' x="',
-          toFixed(-this.width / 2, NUM_FRACTION_DIGITS),
-          '" y="',
-          toFixed(-this.height / 2, NUM_FRACTION_DIGITS),
-          '" width="',
-          toFixed(this.width, NUM_FRACTION_DIGITS),
-          '" height="',
-          toFixed(this.height, NUM_FRACTION_DIGITS),
+            this._getFillAttributes(this.backgroundColor),
+            ' x="',
+            toFixed(-this.width / 2, NUM_FRACTION_DIGITS),
+            '" y="',
+            toFixed(-this.height / 2, NUM_FRACTION_DIGITS),
+            '" width="',
+            toFixed(this.width, NUM_FRACTION_DIGITS),
+            '" height="',
+            toFixed(this.height, NUM_FRACTION_DIGITS),
           '"></rect>\n');
       }
     },
@@ -1203,16 +1203,16 @@
     textContent = textContent.replace(/^\s+|\s+$|\n+/g, '').replace(/\s+/g, ' ');
 
     var text = new fabric.Text(textContent, options),
-      textHeightScaleFactor = text.getHeight() / text.height,
-      lineHeightDiff = (text.height + text.strokeWidth) * text.lineHeight - text.height,
-      scaledDiff = lineHeightDiff * textHeightScaleFactor,
-      textHeight = text.getHeight() + scaledDiff,
-      offX = 0;
+        textHeightScaleFactor = text.getHeight() / text.height,
+        lineHeightDiff = (text.height + text.strokeWidth) * text.lineHeight - text.height,
+        scaledDiff = lineHeightDiff * textHeightScaleFactor,
+        textHeight = text.getHeight() + scaledDiff,
+        offX = 0;
     /*
-     Adjust positioning:
-     x/y attributes in SVG correspond to the bottom-left corner of text bounding box
-     top/left properties in Fabric correspond to center point of text bounding box
-     */
+      Adjust positioning:
+        x/y attributes in SVG correspond to the bottom-left corner of text bounding box
+        top/left properties in Fabric correspond to center point of text bounding box
+    */
     if (text.originX === 'left') {
       offX = text.getWidth() / 2;
     }


### PR DESCRIPTION
Here is a linked issue: https://github.com/kangax/fabric.js/issues/3444.

The problem is that text with textAlign == 'justify' also stretches lines with line breaks and the last line in text, but these lines should be rendered as left aligned.