### PR TITLE
Added ability for objects to be rendered outside group

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -374,15 +374,16 @@
     /**
      * Renders controls and borders for the object
      * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {Boolean} [noTransform] When true, context is not transformed
+     * @param {Object} [styleOverride] properties to override the object style
+     * @param {Object} [childrenOverride] properties to override the children overrides
      */
-    _renderControls: function(ctx, noTransform) {
+    _renderControls: function(ctx, styleOverride, childrenOverride) {
       ctx.save();
       ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
-      this.callSuper('_renderControls', ctx, noTransform);
+      this.callSuper('_renderControls', ctx, styleOverride);
       if (this.canvas && this === this.canvas.getActiveGroup()) {
         for (var i = 0, len = this._objects.length; i < len; i++) {
-          this._objects[i]._renderControls(ctx);
+          this._objects[i]._renderControls(ctx, childrenOverride);
         }
       }
       ctx.restore();

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -929,7 +929,7 @@
      * @param {Boolean} fromLeft When true, context is transformed to object's top/left corner. This is used when rendering text on Node
      */
     transform: function(ctx, fromLeft) {
-      if (this.group && !this.group._transformDone && this.group === this.canvas._activeGroup) {
+      if (this.group && !this.group._transformDone) {
         this.group.transform(ctx);
       }
       var center = fromLeft ? this._getLeftTopCoords() : this.getCenterPoint();
@@ -1045,6 +1045,18 @@
         scaleY *= scaling.scaleY;
       }
       return { scaleX: scaleX, scaleY: scaleY };
+    },
+
+    /**
+     * Return the object opacity counting also the group property
+     * @return {Object} object with scaleX and scaleY properties
+     */
+    getObjectOpacity: function() {
+      var opacity = this.opacity;
+      if (this.group) {
+        opacity *= this.group.getObjectOpacity();
+      }
+      return opacity;
     },
 
     /**
@@ -1258,7 +1270,12 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _setOpacity: function(ctx) {
-      ctx.globalAlpha *= this.opacity;
+      if (this.group && !this.group.transformDone) {
+        ctx.globalAlpha = this.getObjectOpacity();
+      }
+      else {
+        ctx.globalAlpha *= this.opacity;
+      }
     },
 
     _setStrokeStyles: function(ctx, decl) {


### PR DESCRIPTION
If .drawObject or .render is called for an object that is inside a group, the transformation from the parent will be applied so that the object looks like in correct position.

