### PR TITLE
hoverCursor for selectable: false object

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -771,7 +771,7 @@
      * @param {Object} target Object that the mouse is hovering, if so.
      */
     _setCursorFromEvent: function (e, target) {
-      if (!target || !target.selectable) {
+      if (!target) {
         this.setCursor(this.defaultCursor);
         return false;
       }


### PR DESCRIPTION
Allow to display custom cursor also for unselectable items (useful for example if you want to suggest a possible event on mouseclick)