### PR TITLE
Export elements array from svg parser

### DIFF
--- a/src/elements_parser.js
+++ b/src/elements_parser.js
@@ -86,6 +86,6 @@ fabric.ElementsParser.prototype.checkIfDone = function() {
       // eslint-disable-next-line no-eq-null, eqeqeq
       return el != null;
     });
-    this.callback(this.instances);
+    this.callback(this.instances, this.elements);
   }
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -643,9 +643,9 @@
     fabric.gradientDefs[svgUid] = fabric.getGradientDefs(doc);
     fabric.cssRules[svgUid] = fabric.getCSSRules(doc);
     // Precedence of rules:   style > class > attribute
-    fabric.parseElements(elements, function(instances) {
+    fabric.parseElements(elements, function(instances, elements) {
       if (callback) {
-        callback(instances, options);
+        callback(instances, options, elements);
       }
     }, clone(options), reviver, parsingOptions);
   };
@@ -950,8 +950,8 @@
           callback && callback(null);
         }
 
-        fabric.parseSVGDocument(xml.documentElement, function (results, _options) {
-          callback && callback(results, _options);
+        fabric.parseSVGDocument(xml.documentElement, function (results, _options, elements) {
+          callback && callback(results, _options, elements);
         }, reviver, options);
       }
     },


### PR DESCRIPTION
this change does not add any feature, but allows a developer to inspect the element conunterpart of an instance after the parsing. The element counterpart is still attached to its original parent and node tree structure.