### PR TITLE
Fix object removal with custom code

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -875,7 +875,7 @@
     _updateCacheCanvas: function() {
       if (this.noScaleCache && this.canvas && this.canvas._currentTransform) {
         var action = this.canvas._currentTransform.action;
-        if (typeof action !== "function" && action.slice(0, 5) === 'scale') {
+        if (action.slice && action.slice(0, 5) === 'scale') {
           return false;
         }
       }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -875,7 +875,7 @@
     _updateCacheCanvas: function() {
       if (this.noScaleCache && this.canvas && this.canvas._currentTransform) {
         var action = this.canvas._currentTransform.action;
-        if (action.slice(0, 5) === 'scale') {
+        if (typeof action !== "function" && action.slice(0, 5) === 'scale') {
           return false;
         }
       }


### PR DESCRIPTION
If objects get removed by custom code like this

```
fabric.Canvas.prototype.customiseControls({
    tr: {
        action: function( e, target ) {
            // bugfix for text elements in fabric
            let canvas = target.canvas;

            if (canvas.getActiveObject()) {
                canvas.remove(canvas.getActiveObject());
            }
            target.canvas = canvas;

            canvas.deactivateAll();
            canvas.renderAll();
            // do other important stuff after object was removed
        }
    }
}, function() {
});
```

fabricjs crashed because action is a function in this case.