### PR TITLE
call super from path

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -79,10 +79,7 @@
      */
     initialize: function(path, options) {
       options = options || { };
-
-      if (options) {
-        this.setOptions(options);
-      }
+      this.callSuper('initialize', options);
 
       if (!path) {
         path = [];


### PR DESCRIPTION
path is the only object that inherits from Object but does not call super. it should also call super for consistency and to allow overriding of the object initialize prototype.