### PR TITLE
Update rgba regex to account for alpha

### DIFF
--- a/src/color.class.js
+++ b/src/color.class.js
@@ -280,7 +280,7 @@
    * @memberOf fabric.Color
    */
    // eslint-disable-next-line max-len
-  fabric.Color.reRGBa = /^rgba?\(\s*(\d{1,3}(?:\.\d+)?\%?)\s*,\s*(\d{1,3}(?:\.\d+)?\%?)\s*,\s*(\d{1,3}(?:\.\d+)?\%?)\s*(?:\s*,\s*(\d+(?:\.\d+)?)\s*)?\)$/;
+  fabric.Color.reRGBa = /^rgba?\(\s*(\d{1,3}(?:\.\d+)?\%?)\s*,\s*(\d{1,3}(?:\.\d+)?\%?)\s*,\s*(\d{1,3}(?:\.\d+)?\%?)\s*(?:\s*,\s*((?:\d*\.?\d+)?)\s*)?\)$/;
 
   /**
    * Regex matching color in HSL or HSLA formats (ex: hsl(200, 80%, 10%), hsla(300, 50%, 80%, 0.5), hsla( 300 , 50% , 80% , 0.5 ))

--- a/test/unit/color.js
+++ b/test/unit/color.js
@@ -191,7 +191,7 @@
     equal(oColor.toHex(), 'FFFFFF');
     equal(oColor.getAlpha(), 0.3, 'alpha should be set properly');
   });
-  
+
   test('fromRgba (with whitespaces)', function() {
     var originalRgba = 'rgba( 255 , 255 , 255 , 0.5 )';
     var oColor = fabric.Color.fromRgba(originalRgba);

--- a/test/unit/color.js
+++ b/test/unit/color.js
@@ -184,6 +184,14 @@
     equal(oColor.getAlpha(), 0.5, 'alpha should be set properly');
   });
 
+  test('fromRgba (with missing 0)', function() {
+    var originalRgba = 'rgba( 255 , 255 , 255 , .3 )';
+    var oColor = fabric.Color.fromRgba(originalRgba);
+    equal(oColor.toRgba(), 'rgba(255,255,255,0.3)');
+    equal(oColor.toHex(), 'FFFFFF');
+    equal(oColor.getAlpha(), 0.3, 'alpha should be set properly');
+  });
+  
   test('fromRgba (with whitespaces)', function() {
     var originalRgba = 'rgba( 255 , 255 , 255 , 0.5 )';
     var oColor = fabric.Color.fromRgba(originalRgba);


### PR DESCRIPTION
Previous regex would fail for an rgba string with a non integer alpha value. "rgba(255, 128, 64, .5)"

closes #4004