### PR TITLE
Limit cache size to upper and lower limit

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -62,6 +62,31 @@ fabric.reNum = '(?:[-+]?(?:\\d+|\\d*\\.\\d+)(?:e[-+]?\\d+)?)';
 fabric.fontPaths = { };
 fabric.iMatrix = [1, 0, 0, 1, 0, 0];
 fabric.canvasModule = 'canvas';
+
+/**
+ * Pixel limit for cache canvases. 1Mpx , 4Mpx should be fine.
+ * @since 1.7.14
+ * @type Number
+ * @default
+ */
+fabric.perfLimitSizeTotal = 2097152;
+
+/**
+ * Pixel limit for cache canvases width or height. IE fixes the maximum at 5000
+ * @since 1.7.14
+ * @type Number
+ * @default
+ */
+fabric.cacheSideLimit = 4096;
+
+/**
+ * Lowest pixel limit for cache canvases, set at 256PX
+ * @since 1.7.14
+ * @type Number
+ * @default
+ */
+fabric.minCacheSideLimit = 256;
+
 /**
  * Cache Object for widths of chars in text rendering.
  */

--- a/HEADER.js
+++ b/HEADER.js
@@ -77,7 +77,7 @@ fabric.perfLimitSizeTotal = 2097152;
  * @type Number
  * @default
  */
-fabric.cacheSideLimit = 4096;
+fabric.maxCacheSideLimit = 4096;
 
 /**
  * Lowest pixel limit for cache canvases, set at 256PX

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -313,7 +313,7 @@
     },
 
     /**
-     * Decide if the object should cache or not.
+     * Decide if the object should cache or not. Create its own cache level
      * objectCaching is a global flag, wins over everything
      * needsItsOwnCache should be used when the object drawing method requires
      * a cache step. None of the fabric classes requires it.
@@ -321,17 +321,17 @@
      * @return {Boolean}
      */
     shouldCache: function() {
-      var parentCache = this.objectCaching && (!this.group || this.needsItsOwnCache() || !this.group.isCaching());
-      this.caching = parentCache;
-      if (parentCache) {
+      var ownCache = this.objectCaching && (!this.group || this.needsItsOwnCache() || !this.group.isOnACache());
+      this.ownCaching = ownCache;
+      if (ownCache) {
         for (var i = 0, len = this._objects.length; i < len; i++) {
           if (this._objects[i].willDrawShadow()) {
-            this.caching = false;
+            this.ownCaching = false;
             return false;
           }
         }
       }
-      return parentCache;
+      return ownCache;
     },
 
     /**
@@ -354,8 +354,8 @@
      * Check if this group or its parent group are caching, recursively up
      * @return {Boolean}
      */
-    isCaching: function() {
-      return this.caching || this.group && this.group.isCaching();
+    isOnACache: function() {
+      return this.ownCaching || (this.group && this.group.isOnACache());
     },
 
     /**
@@ -413,11 +413,6 @@
      * @private
      */
     _renderObject: function(object, ctx) {
-      // do not render if object is not visible
-      if (!object.visible) {
-        return;
-      }
-
       var originalHasRotatingPoint = object.hasRotatingPoint;
       object.hasRotatingPoint = false;
       object.render(ctx);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -846,27 +846,33 @@
      * and each side do not cross fabric.cacheSideLimit
      * those numbers are configurable so that you can get as much detail as you want
      * making bargain with performances.
-     * @private
+     * @param {Object} dims
+     * @param {Object} dims.width width of canvas
+     * @param {Object} dims.height height of canvas
+     * @param {Object} dims.zoomX zoomX zoom value to unscale the canvas before drawing cache
+     * @param {Object} dims.zoomY zoomY zoom value to unscale the canvas before drawing cache
+     * @return {Object}.width width of canvas
+     * @return {Object}.height height of canvas
+     * @return {Object}.zoomX zoomX zoom value to unscale the canvas before drawing cache
+     * @return {Object}.zoomY zoomY zoom value to unscale the canvas before drawing cache
      */
     _limitCacheSize: function(dims) {
       var perfLimitSizeTotal = fabric.perfLimitSizeTotal,
           maximumSide = fabric.cacheSideLimit,
           width = dims.width, height = dims.height,
-          ar = width / height, limitedDims = fabric.util.limitDimsByArea(ar, perfLimitSizeTotal, maximumSide);
-      if (width > limitedDims.x) {
-        dims.zoomX /= dims.width / limitedDims.x;
-        dims.width = limitedDims.x;
+          ar = width / height, limitedDims = fabric.util.limitDimsByArea(ar, perfLimitSizeTotal, maximumSide),
+          capValue = fabric.util.capValue, max = fabric.cacheSideLimit, min = fabric.minCacheSideLimit,
+          x = capValue(min, limitedDims.x, max),
+          y = capValue(min, limitedDims.y, max);
+      if (width > x) {
+        dims.zoomX /= dims.width / x;
+        dims.width = x;
       }
-      if (height > limitedDims.y) {
-        dims.zoomY /= dims.height / limitedDims.y;
-        dims.height = limitedDims.y;
+      if (height > y) {
+        dims.zoomY /= dims.height / y;
+        dims.height = y;
       }
-      return {
-        width: dims.width,
-        height: dims.height,
-        zoomX: dims.zoomX,
-        zoomY: dims.zoomY,
-      };
+      return dims;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1083,7 +1083,7 @@
         this.dirty = true;
       }
 
-      if (this.group && this.stateProperties.indexOf(key) > -1) {
+      if (this.group && this.stateProperties.indexOf(key) > -1 && this.group.isOnACache()) {
         this.group.set('dirty', true);
       }
 
@@ -1140,7 +1140,6 @@
         return;
       }
       ctx.save();
-      //setup fill rule for current object
       this._setupCompositeOperation(ctx);
       this.drawSelectionBackground(ctx);
       this.transform(ctx);
@@ -1185,7 +1184,7 @@
     },
 
     /**
-     * Decide if the object should cache or not.
+     * Decide if the object should cache or not. Create its own cache level
      * objectCaching is a global flag, wins over everything
      * needsItsOwnCache should be used when the object drawing method requires
      * a cache step. None of the fabric classes requires it.
@@ -1193,8 +1192,9 @@
      * @return {Boolean}
      */
     shouldCache: function() {
-      return this.objectCaching &&
-      (!this.group || this.needsItsOwnCache() || !this.group.isCaching());
+      this.ownCaching = this.objectCaching &&
+      (!this.group || this.needsItsOwnCache() || !this.group.isOnACache());
+      return this.ownCaching;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -9,7 +9,8 @@
       capitalize = fabric.util.string.capitalize,
       degreesToRadians = fabric.util.degreesToRadians,
       supportsLineDash = fabric.StaticCanvas.supports('setLineDash'),
-      objectCaching = !fabric.isLikelyNode;
+      objectCaching = !fabric.isLikelyNode,
+      ALIASING_LIMIT = 2;
 
   if (fabric.Object) {
     return;
@@ -861,16 +862,22 @@
           maximumSide = fabric.cacheSideLimit,
           width = dims.width, height = dims.height,
           ar = width / height, limitedDims = fabric.util.limitDimsByArea(ar, perfLimitSizeTotal, maximumSide),
-          capValue = fabric.util.capValue, max = fabric.cacheSideLimit, min = fabric.minCacheSideLimit,
+          capValue = fabric.util.capValue, max = fabric.maxCacheSideLimit, min = fabric.minCacheSideLimit,
           x = capValue(min, limitedDims.x, max),
           y = capValue(min, limitedDims.y, max);
       if (width > x) {
-        dims.zoomX /= dims.width / x;
+        dims.zoomX /= width / x;
         dims.width = x;
       }
+      else if (width < min) {
+        dims.width = min;
+      }
       if (height > y) {
-        dims.zoomY /= dims.height / y;
+        dims.zoomY /= height / y;
         dims.height = y;
+      }
+      else if (height < min) {
+        dims.height = min;
       }
       return dims;
     },
@@ -894,8 +901,8 @@
           width = dim.x * zoomX,
           height = dim.y * zoomY;
       return {
-        width: width + 2,
-        height: height + 2,
+        width: width + ALIASING_LIMIT,
+        height: height + ALIASING_LIMIT,
         zoomX: zoomX,
         zoomY: zoomY
       };

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -690,6 +690,25 @@
       else if (fabric.charWidthsCache[fontFamily]) {
         delete fabric.charWidthsCache[fontFamily];
       }
+    },
+
+    /**
+     * Clear char widths cache for a font family.
+     * @memberOf fabric.util
+     * @param {Number} ar aspect ratio
+     * @param {Number} maximumArea Maximum area you want to achieve
+     * @param {Number} maximumSide biggest side allowed
+     * @return {Object.x} Limited dimensions by X
+     * @return {Object.y} Limited dimensions by Y
+     */
+    limitDimsByArea: function(ar, maximumArea) {
+      var roughWidth = Math.sqrt(maximumArea * ar),
+          perfLimitSizeY = Math.floor(maximumArea / roughWidth);
+      return { x: Math.floor(roughWidth), y: perfLimitSizeY };
+    },
+
+    capValue: function(min, value, max) {
+      return Math.max(min, Math.min(value, max));
     }
   };
 

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -49,6 +49,9 @@
 
   QUnit.module('fabric.Object', {
     teardown: function() {
+      fabric.perfLimitSizeTotal = 2097152;
+      fabric.maxCacheSideLimit = 4096;
+      fabric.minCacheSideLimit = 256;
       canvas.clear();
       canvas.backgroundColor = fabric.Canvas.prototype.backgroundColor;
       canvas.calcOffset();
@@ -1196,6 +1199,9 @@
   });
 
   test('_updateCacheCanvas check if cache canvas should be updated', function() {
+    fabric.perfLimitSizeTotal = 10000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 1;
     var object = new fabric.Object({ width: 10, height: 10, strokeWidth: 0 });
     object._createCacheCanvas();
     equal(object.cacheWidth, 12, 'current cache dimensions are saved');
@@ -1210,6 +1216,108 @@
     equal(object.cacheWidth, 6, 'current cache dimensions is updated');
     object.strokeWidth = 2;
     equal(object._updateCacheCanvas(), true, 'if strokeWidth change, it returns true');
+  });
+
+  test('_limitCacheSize limit min to 256', function() {
+    fabric.perfLimitSizeTotal = 10000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 200, height: 200, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, 256, 'width gets minimum to the cacheSideLimit');
+    equal(dims.height, 256, 'height gets minimum to the cacheSideLimit');
+    equal(zoomX, dims.zoomX, 'zoom factor X does not need a change');
+    equal(zoomY, dims.zoomY, 'zoom factor Y does not need a change');
+  });
+
+  test('_limitCacheSize does not limit if not necessary', function() {
+    fabric.perfLimitSizeTotal = 1000000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 400, height: 400, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, 402, 'width is in the middle of limits');
+    equal(dims.height, 402, 'height is in the middle of limits');
+    equal(zoomX, dims.zoomX, 'zoom factor X does not need a change');
+    equal(zoomY, dims.zoomY, 'zoom factor Y does not need a change');
+  });
+
+  test('_limitCacheSize does cap up minCacheSideLimit', function() {
+    fabric.perfLimitSizeTotal = 10000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 400, height: 400, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var width = dims.width;
+    var height = dims.height;
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, 256, 'width is capped to min');
+    equal(dims.height, 256, 'height is capped to min');
+    equal(zoomX * dims.width / width, dims.zoomX, 'zoom factor X gets updated to represent the shrink');
+    equal(zoomY * dims.height / height, dims.zoomY, 'zoom factor Y gets updated to represent the shrink');
+  });
+
+  test('_limitCacheSize does cap up if necessary', function() {
+    fabric.perfLimitSizeTotal = 1000000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 2046, height: 2046, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var width = dims.width;
+    var height = dims.height;
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, 1000, 'width is capped to max allowed by area');
+    equal(dims.height, 1000, 'height is capped to max allowed by area');
+    equal(zoomX * dims.width / width, dims.zoomX, 'zoom factor X gets updated to represent the shrink');
+    equal(zoomY * dims.height / height, dims.zoomY, 'zoom factor Y gets updated to represent the shrink');
+  });
+
+  test('_limitCacheSize does cap up if necessary to maxCacheSideLimit', function() {
+    fabric.perfLimitSizeTotal = 100000000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 8192, height: 8192, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, fabric.maxCacheSideLimit, 'width is capped to max allowed by fabric');
+    equal(dims.height, fabric.maxCacheSideLimit, 'height is capped to max allowed by fabric');
+    equal(dims.zoomX, zoomX * 4096 / 8194, 'zoom factor X gets updated to represent the shrink');
+    equal(dims.zoomY, zoomY * 4096 / 8194, 'zoom factor Y gets updated to represent the shrink');
+  });
+
+  test('_limitCacheSize does cap up if necessary to maxCacheSideLimit, different AR', function() {
+    fabric.perfLimitSizeTotal = 100000000;
+    fabric.maxCacheSideLimit = 4096;
+    fabric.minCacheSideLimit = 256;
+    var object = new fabric.Object({ width: 16384, height: 8192, strokeWidth: 0 });
+    var dims = object._getCacheCanvasDimensions();
+    var width = dims.width;
+    var height = dims.height;
+    var zoomX = dims.zoomX;
+    var zoomY = dims.zoomY;
+    var limitedDims = object._limitCacheSize(dims);
+    equal(dims, limitedDims, 'object is mutated');
+    equal(dims.width, fabric.maxCacheSideLimit, 'width is capped to max allowed by fabric');
+    equal(dims.height, fabric.maxCacheSideLimit, 'height is capped to max allowed by fabric');
+    equal(dims.zoomX, zoomX * fabric.maxCacheSideLimit / width, 'zoom factor X gets updated to represent the shrink');
+    equal(dims.zoomY, zoomY * fabric.maxCacheSideLimit / height, 'zoom factor Y gets updated to represent the shrink');
   });
 
   test('_setShadow', function(){

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -884,7 +884,7 @@
   });
 
   test('fabric.util.limitDimsByArea ar < 1', function() {
-    var dims = fabric.util.limitDimsByArea(1/3, 10000);
+    var dims = fabric.util.limitDimsByArea(1 / 3, 10000);
     equal(dims.x, 57);
     equal(dims.y, 173);
   });

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -859,7 +859,7 @@
   });
 
   test('get bounds of arc', function() {
-    ok(typeof fabric.util.getBoundsOfArc == 'function');
+    ok(typeof fabric.util.getBoundsOfArc === 'function');
     var bounds = fabric.util.getBoundsOfArc(0, 0, 50, 30, 0, 1, 1, 100, 100);
     var expectedBounds = [
       { x: 0, y: -8.318331151877368 },
@@ -868,5 +868,42 @@
       { x: 147.19721858646224, y: 100 }
     ];
     deepEqual(bounds, expectedBounds, 'bounds are as expected');
+  });
+
+  test('fabric.util.limitDimsByArea', function() {
+    ok(typeof fabric.util.limitDimsByArea === 'function');
+    var dims = fabric.util.limitDimsByArea(1, 10000);
+    equal(dims.x, 100);
+    equal(dims.y, 100);
+  });
+
+  test('fabric.util.limitDimsByArea ar > 1', function() {
+    var dims = fabric.util.limitDimsByArea(3, 10000);
+    equal(dims.x, 173);
+    equal(dims.y, 57);
+  });
+
+  test('fabric.util.limitDimsByArea ar < 1', function() {
+    var dims = fabric.util.limitDimsByArea(1/3, 10000);
+    equal(dims.x, 57);
+    equal(dims.y, 173);
+  });
+
+  test('fabric.util.capValue ar < 1', function() {
+    ok(typeof fabric.util.capValue === 'function');
+    var val = fabric.util.capValue(3, 10, 70);
+    equal(val, 10, 'value is not capped');
+  });
+
+  test('fabric.util.capValue ar < 1', function() {
+    ok(typeof fabric.util.capValue === 'function');
+    var val = fabric.util.capValue(3, 1, 70);
+    equal(val, 3, 'min cap');
+  });
+
+  test('fabric.util.capValue ar < 1', function() {
+    ok(typeof fabric.util.capValue === 'function');
+    var val = fabric.util.capValue(3, 80, 70);
+    equal(val, 70, 'max cap');
   });
 })();


### PR DESCRIPTION
Add a system to cap the cache canvas in this way:

maximum area is defined,
minimum side and maximum side is defined.

This aims to keep cache canvas under certains dimensions ( no more than 2Mega pixel), respect aspect ratio when limiting

Do not got below the 256 px limit where some browser stop accelerating the canvases.