### PR TITLE
Improve performance of copyGLTo2D in Firefox & potentially other browers

### DIFF
--- a/build.js
+++ b/build.js
@@ -270,6 +270,7 @@ else {
       exec(mininfierCmd, function (error, output) {
         if (error) {
           console.error('Minification failed using', minifier, 'with', mininfierCmd);
+          console.error('Minifier error output:\n' + error);
           process.exit(1);
         }
         console.log('Minified using', minifier, 'to ' + distributionPath + 'fabric.min.js');


### PR DESCRIPTION
Why:

* Copying data to 2d canvas from GL context dominates filtering time when using webgl
* Chrome is happy to copy data from GL with ctx.drawImage in sub-millisecond time
* Firefox performs drawImage much more slowly but can do putImageData quite fast instead
* Using putImageData results in ~ 2-3x speedup on Firefox 54 in the fabricjs.com filtering demo on my Macbook Pro

This change addresses the need by:

* Adding a runtime check for which copy func performs better
* Swaps drawImage for putImageData if that func is detected as being faster

Also submitted for review:

* Log minifier error output to console if build.js minifyCmd fails (helps identify syntax errors while using build:watch)