### PR TITLE
bugfix for group.fromObject

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -563,8 +563,9 @@
    */
   fabric.Group.fromObject = function(object, callback) {
     fabric.util.enlivenObjects(object.objects, function(enlivenedObjects) {
-      delete object.objects;
-      callback && callback(new fabric.Group(enlivenedObjects, object, true));
+      var options = fabric.util.object.clone(object, true);
+      delete options.objects;
+      callback && callback(new fabric.Group(enlivenedObjects, options, true));
     });
   };
 


### PR DESCRIPTION
no longer deletes the objects from the group data object when enlivening.