### PR TITLE
Fixed "install Cairo" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Fabric.js started as a foundation for design editor on [printio.ru](http://print
     $ bower install fabric
 
 <h3 id="npm-install">Install with npm</h3>
+
 To install Fabric.js using npm, you must first manually [install Cairo](http://cairographics.org/download/) on your system. Cairo is a system library which powers node-canvas, which Fabric.js relies on. When the installation is complete, you may need to restart your terminal or command prompt before installing fabric.
 
     $ npm install fabric --save


### PR DESCRIPTION
GitHub wasn't parsing that paragraph for Markdown links, since there were no blank lines between it and the previous <h3>.