### PR TITLE
Allow multiple keys to enable multiple click selection

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -518,7 +518,7 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } else if (e[selectionKeys.toString()]){
+      } else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -518,7 +518,8 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } else if (e[this.selectionKeys.toString()]){
+      } 
+      else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -124,15 +124,15 @@
     selection:              true,
 
     /**
-     * Indicates which key enable multiple click selection
+     * Indicates which keys enable multiple click selection
      * values: 'altKey', 'shiftKey', 'ctrlKey'.
-     * If `null` or 'none' or any other string that is not a modifier key
-     * feature is disabled feature disabled.
+     * If `null` or empty or containing any other string that is not a modifier key
+     * feature is disabled.
      * @since 1.6.2
-     * @type String
+     * @type Array
      * @default
      */
-    selectionKey:           'shiftKey',
+    selectionKeys:           ['shiftKey'],
 
     /**
      * Indicates which key enable alternative selection
@@ -512,6 +512,14 @@
     _shouldClearSelection: function (e, target) {
       var activeObjects = this.getActiveObjects(),
           activeObject = this._activeObject;
+
+      var selectionKeyPressed = false;
+      this.selectionKeys.forEach(function (selectionKey) {
+        if (e[selectionKey]){
+          selectionKeyPressed = true;
+        }
+      });
+
       return (
         !target
         ||
@@ -520,7 +528,7 @@
           activeObjects.length > 1 &&
           activeObjects.indexOf(target) === -1 &&
           activeObject !== target &&
-          !e[this.selectionKey])
+          !selectionKeyPressed)
         ||
         (target && !target.evented)
         ||

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -518,7 +518,7 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } 
+      }
       else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -514,11 +514,13 @@
           activeObject = this._activeObject;
 
       var selectionKeyPressed = false;
-      this.selectionKeys.forEach(function (selectionKey) {
-        if (e[selectionKey]){
-          selectionKeyPressed = true;
-        }
-      });
+      if (this.selectionKeys.isArray()){
+        selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
+          return e[selectionKey];
+        });
+      } else if (e[selectionKeys.toString()]){
+        selectionKeyPressed = true;
+      }
 
       return (
         !target

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -514,7 +514,7 @@
           activeObject = this._activeObject;
 
       var selectionKeyPressed = false;
-      if (this.selectionKeys.isArray()){
+      if (Array.isArray(this.selectionKeys)){
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -15,11 +15,13 @@
       var activeObject = this._activeObject;
 
       var selectionKeyPressed = false;
-      this.selectionKeys.forEach(function (selectionKey) {
-        if (e[selectionKey]){
-          selectionKeyPressed = true;
-        }
-      });
+      if (this.selectionKeys.isArray()){
+        selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
+          return e[selectionKey];
+        });
+      } else if (e[selectionKeys.toString()]){
+        selectionKeyPressed = true;
+      }
 
       return activeObject && selectionKeyPressed && target && target.selectable && this.selection &&
             (activeObject !== target || activeObject.type === 'activeSelection');

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,7 +13,15 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      return activeObject && e[this.selectionKey] && target && target.selectable && this.selection &&
+
+      var selectionKeyPressed = false;
+      this.selectionKeys.forEach(function (selectionKey) {
+        if (e[selectionKey]){
+          selectionKeyPressed = true;
+        }
+      });
+
+      return activeObject && selectionKeyPressed && target && target.selectable && this.selection &&
             (activeObject !== target || activeObject.type === 'activeSelection');
     },
 

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -19,7 +19,8 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } else if (e[this.selectionKeys.toString()]){
+      } 
+      else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }
 

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -15,7 +15,7 @@
       var activeObject = this._activeObject;
 
       var selectionKeyPressed = false;
-      if (this.selectionKeys.isArray()){
+      if (Array.isArray(this.selectionKeys)){
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -19,7 +19,7 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } 
+      }
       else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -19,7 +19,7 @@
         selectionKeyPressed = this.selectionKeys.some(function (selectionKey) {
           return e[selectionKey];
         });
-      } else if (e[selectionKeys.toString()]){
+      } else if (e[this.selectionKeys.toString()]){
         selectionKeyPressed = true;
       }
 


### PR DESCRIPTION
Changed selectionKey to an array in order to allow multiple keys to enable multi click selection.  I thought this would be useful since, in my application that uses fabric.js, I would like to make it so that holding either shift or ctrl will enable multi selection.  This is consistent with the behavior in other editors like Google Slides.