### PR TITLE
Simplify setSubscript, setSuperscript

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -176,7 +176,7 @@
      */
     superscript: {
       size:      0.60, // fontSize factor
-      baseline:  0.67  // baseline-shift factor (upwards)
+      baseline:  -0.67  // baseline-shift factor (upwards)
     },
 
     /**
@@ -186,7 +186,7 @@
      */
     subscript: {
       size:      0.62, // fontSize factor
-      baseline: -0.25  // baseline-shift factor (downwards)
+      baseline: 0.25  // baseline-shift factor (downwards)
     },
 
     /**
@@ -1161,7 +1161,7 @@
      */
     _setScript: function(line, char, schema) {
       var fontSize = this.getValueOfPropertyAt(line, char, 'fontSize'),
-          baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * -schema.baseline;
+          baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * schema.baseline;
       this.setPropertyAt(line, char, 'deltaY', baseline);
       this.setPropertyAt(line, char, 'fontSize', fontSize * schema.size);
       return this;

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1151,11 +1151,20 @@
       return this._setScript(line, char, this.subscript);
     },
 
+    /**
+     * Turns the character into an 'inferior figure' (aka. 'subscript')
+     * @param {Number} line the line number or starting position
+     * @param {Number} char the character number or final position
+     * @param {Object} schema either this.superscript or this.subscript
+     * @returns {Object} this
+     * @private
+     */
     _setScript: function(line, char, schema) {
       var fontSize = this.getValueOfPropertyAt(line, char, 'fontSize'),
           baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * schema.baseline;
       this.setPropertyAt(line, char, 'deltaY', baseline);
       this.setPropertyAt(line, char, 'fontSize', fontSize * schema.size);
+      return this;
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1161,7 +1161,7 @@
      */
     _setScript: function(line, char, schema) {
       var fontSize = this.getValueOfPropertyAt(line, char, 'fontSize'),
-          baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * schema.baseline;
+          baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * -schema.baseline;
       this.setPropertyAt(line, char, 'deltaY', baseline);
       this.setPropertyAt(line, char, 'fontSize', fontSize * schema.size);
       return this;

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -855,11 +855,6 @@
      * @return {Number} fontSize of the character
      */
     getHeightOfChar: function(line, char) {
-      var size = this.getValueOfPropertyAt(line, char, '*fontSize');
-      if (typeof size === 'number') {
-        return size;
-      }
-
       return this.getValueOfPropertyAt(line, char, 'fontSize');
     },
 
@@ -1143,7 +1138,7 @@
      * @returns {Object} this
      */
     setSuperscript: function(line, char) {
-      return this.superscript.apply(this, line, char);
+      return this._setScript(line, char, this.superscript);
     },
 
     /**
@@ -1153,7 +1148,14 @@
      * @returns {Object} this
      */
     setSubscript: function(line, char) {
-      return this.subscript.apply(this, line, char);
+      return this._setScript(line, char, this.subscript);
+    },
+
+    _setScript: function(line, char, schema) {
+      var fontSize = this.getValueOfPropertyAt(line, char, 'fontSize'),
+          baseline = this.getValueOfPropertyAt(line, char, 'deltaY') + fontSize * schema.baseline;
+      this.setPropertyAt(line, char, 'deltaY', baseline);
+      this.setPropertyAt(line, char, 'fontSize', fontSize * schema.size);
     },
 
     /**
@@ -1169,7 +1171,7 @@
               prevStyle.fontFamily !== thisStyle.fontFamily ||
               prevStyle.fontWeight !== thisStyle.fontWeight ||
               prevStyle.fontStyle !== thisStyle.fontStyle ||
-              prevStyle.deltaY != thisStyle.deltaY
+              prevStyle.deltaY !== thisStyle.deltaY
       );
     },
 
@@ -1258,6 +1260,10 @@
 
       if (charStyle && typeof charStyle[property] !== 'undefined') {
         return charStyle[property];
+      }
+      if (property === 'deltaY') {
+        // if did not find deltaY in style, return 0
+        return 0;
       }
 
       return this[property];
@@ -1441,87 +1447,6 @@
     complexity: function() {
       return 1;
     }
-  }, function(prototype, Text) {
-    prototype.superscript.apply = prototype.subscript.apply =
-      /**
-       * Mutates the style at given position in 'self' based on values from 'this'
-       * @param {Object} self the object to be mutated
-       * @param {Number} line the line number or the starting position
-       * @param {Number} char the character number or the final position
-       * @returns {Object} self
-       */
-      function(self, line, char) {
-        var schema = this;
-        var apply = function(line, char) {
-          var l = self._textLines[line];
-          if (l == null || typeof l[char] !== 'string') {
-            return self;
-          }
-
-          var size = self.getValueOfPropertyAt(line, char, 'fontSize');
-          if (typeof self.getValueOfPropertyAt(line, char, '*fontSize') !== 'number') {
-            self.setPropertyAt(line, char, '*fontSize', size);
-          }
-
-          var dy = self.getValueOfPropertyAt(line, char, 'deltaY') || 0;
-          self.setPropertyAt(line, char, 'fontSize', size * schema.size);
-          self.setPropertyAt(line, char, 'deltaY', dy + size * -schema.baseline);
-          return self;
-        };
-
-        if (typeof line === 'number') {
-          if (typeof char === 'number') {
-            return apply(line, char);
-          }
-
-          var c1 = char[0], c2 = char[1];
-          if (c1 >= c2) {
-            return self;
-          }
-
-          for (var c = c1; c <= c2; c++) {
-            apply(line, c, this);
-          }
-          return self;
-        }
-
-        var l1 = line[0], C1 = line[1];
-        if (typeof char !== 'object') {
-          return apply(l1, C1);
-        }
-
-        var l2 = char[0], C2 = char[1];
-        if (l1 > l2) {
-          return self;
-        }
-
-        var lines = self._textLines;
-        for (var l = l1; l <= l2; l++) {    // lines
-          line = lines[l];
-          if (line == null) {
-            break;
-          }
-
-          var c1 = 0, c2 = line.length - 1;
-          switch (l) {
-            case l1:
-              c1 = C1;
-              break;
-
-            case l2:
-              c2 = C2;
-          }
-
-          if (l1 == l2 && c1 == c2 || c1 > c2) {
-            break;
-          }
-          for (var c = c1; c <= c2; c++) {  // characters
-            apply(l, c);
-          }
-        }
-
-        return self;
-      };
   });
 
   /* _FROM_SVG_START_ */

--- a/src/util/lang_class.js
+++ b/src/util/lang_class.js
@@ -13,10 +13,6 @@
 
       /** @ignore */
       addMethods = function(klass, source, parent) {
-        if (typeof source === 'function') {
-          return source(klass.prototype, klass, parent);
-        }
-
         for (var property in source) {
 
           if (property in klass.prototype &&

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -383,65 +383,47 @@
   });
 
   test('text superscript - single char', function() {
-    var text = new fabric.Text('xxx');
+    var text = new fabric.Text('xxx', { styles: {
+      0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
+    } });
     var size = text.fontSize;
     var schema = text.superscript;
+    var styleFontSize = text.styles[0][2].fontSize;
+    var styleDeltaY = text.styles[0][2].deltaY;
 
     ok(typeof text.setSuperscript === 'function');
     text.setSuperscript(0, 1);
-
-    equal(text.styles[0][0].fontSize, size, 'character 0: fontSize remained the same');
+    text.setSuperscript(0, 2);
+    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize remained the same');
     equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
     equal(text.styles[0][1].fontSize, size * schema.size, 'character 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * -schema.baseline, 'character 1: deltaY has been set');
-  });
+    equal(text.styles[0][1].deltaY, size * schema.baseline, 'character 1: deltaY has been set');
 
-  test('text superscript - same line, many chars', function() {
-    var text = new fabric.Text('xxx');
-    var size = text.fontSize;
-    var schema = text.superscript;
-    text.setSuperscript(0, [1, 2]);
-
-    equal(text.styles[0][0].fontSize, size, 'character 0: fontSize remained the same');
-    equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
-
-    equal(text.styles[0][1].fontSize, size * schema.size, 'character 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * -schema.baseline, 'character 1: deltaY has been set');
-
-    equal(text.styles[0][2].fontSize, size * schema.size, 'character 2: fontSize was reduced');
-    equal(text.styles[0][2].deltaY, size * -schema.baseline, 'character 2: deltaY has been set');
-  });
-
-  test('text superscript - many lines', function() {
-    var text = new fabric.Text('xx\nx');
-    var size = text.fontSize;
-    var schema = text.superscript;
-    text.setSuperscript([0, 1], [1, 0]);
-
-    equal(text.styles[0][0].fontSize, size, 'line 0, char 0: fontSize remained the same');
-    equal(text.styles[0][0].deltaY, undefined, 'line 0, char 0: deltaY is not set');
-
-    equal(text.styles[0][1].fontSize, size * schema.size, 'line 0, char 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * -schema.baseline, 'line 0, char 1: deltaY has been set');
-
-    equal(text.styles[1][0].fontSize, size * schema.size, 'line 1, char 0: fontSize was reduced');
-    equal(text.styles[1][0].deltaY, size * -schema.baseline, 'line 1, char 0: deltaY has been set');
+    equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize was reduced from the style one');
+    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been incremented');
   });
 
   test('text subscript - single char', function() {
-    var text = new fabric.Text('xxx');
+    var text = new fabric.Text('xxx', { styles: {
+      0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
+    } });
     var size = text.fontSize;
     var schema = text.subscript;
+    var styleFontSize = text.styles[0][2].fontSize;
+    var styleDeltaY = text.styles[0][2].deltaY;
 
-    ok(typeof text.setSubscript === 'function');
+    ok(typeof text.setSuperscript === 'function');
     text.setSubscript(0, 1);
-
-    equal(text.styles[0][0].fontSize, size, 'character 0: fontSize remained the same');
+    text.setSubscript(0, 2);
+    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize remained the same');
     equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
     equal(text.styles[0][1].fontSize, size * schema.size, 'character 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * -schema.baseline, 'character 1: deltaY has been set');
+    equal(text.styles[0][1].deltaY, size * schema.baseline, 'character 1: deltaY has been set');
+
+    equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize was reduced from the style one');
+    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been incremented');
   });
 
 })();


### PR DESCRIPTION
There are some reasons behind having the code in this simpler form:

1) providing that we are not duplicating code or violating any normal coding good practice, this code is smaller.

2) The functionality behind `*fontSize` was a singular case that would have need its own doc, explanation

3) all the fabric functions for style set char by char, introducing a `many lines, many chars` would have make the other methods impair. Also we have setSelectionStyles to do this and can be used in the same way.

4) i believe that for who comes tomorrow this function _setScript is very easy to read.