### PR TITLE
Remove fabric.Object.remove

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1665,16 +1665,6 @@
     },
 
     /**
-     * Removes object from canvas to which it was added last
-     * @return {fabric.Object} thisArg
-     * @chainable
-     */
-    remove: function() {
-      this.canvas && this.canvas.remove(this);
-      return this;
-    },
-
-    /**
      * Returns coordinates of a pointer relative to an object
      * @param {Event} e Event to operate upon
      * @param {Object} [pointer] Pointer to operate upon (instead of event)

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -778,17 +778,6 @@
     ok(object2.canvas === canvas);
   });
 
-  test('remove', function() {
-    var object = new fabric.Object();
-
-    ok(typeof object.remove == 'function');
-
-    canvas.add(object);
-    equal(object.remove(), object, 'should be chainable');
-
-    equal(canvas.getObjects().length, 0);
-  });
-
   test('object:removed', function() {
     var object = new fabric.Object();
     var removedEventFired = false;
@@ -796,7 +785,7 @@
     canvas.add(object);
 
     object.on('removed', function(){ removedEventFired = true; });
-    object.remove();
+    canvas.remove(object);
 
     ok(removedEventFired);
   });


### PR DESCRIPTION
close #4195

Object.remove was a sort of alias of canvas.remove(object).

This was colliding with group.remove and activeSelection.remove that mix from collection and object togheter, letting them have a remove method that is different from the base one.

Canvas.remove is enough, we do not need a duplicate.