### PR TITLE
enhanced `_renderTextDecoration`, `renderCursor`; tests

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -445,7 +445,8 @@
           charHeight = this.getValueOfPropertyAt(lineIndex, charIndex, 'fontSize'),
           multiplier = this.scaleX * this.canvas.getZoom(),
           cursorWidth = this.cursorWidth / multiplier,
-          topOffset = boundaries.topOffset;
+          topOffset = boundaries.topOffset,
+          dy = this.getValueOfPropertyAt(lineIndex, charIndex, 'deltaY');
 
       topOffset += (1 - this._fontSizeFraction) * this.getHeightOfLine(lineIndex) / this.lineHeight
         - charHeight * (1 - this._fontSizeFraction);
@@ -458,7 +459,7 @@
       ctx.globalAlpha = this.__isMousedown ? 1 : this._currentCursorOpacity;
       ctx.fillRect(
         boundaries.left + boundaries.leftOffset - cursorWidth / 2,
-        topOffset + boundaries.top,
+        topOffset + boundaries.top + dy,
         cursorWidth,
         charHeight);
     },

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -382,48 +382,52 @@
     equal(cache, cache2, 'you get the same cache');
   });
 
-  test('text superscript - single char', function() {
+  test('text superscript', function() {
     var text = new fabric.Text('xxx', { styles: {
       0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
     } });
+    ok(typeof text.setSuperscript === 'function');
+    
     var size = text.fontSize;
-    var schema = text.superscript;
+    var scale = text.downsizing[0];
+    var shift = text.baselineShift[0];
     var styleFontSize = text.styles[0][2].fontSize;
     var styleDeltaY = text.styles[0][2].deltaY;
-
-    ok(typeof text.setSuperscript === 'function');
     text.setSuperscript(0, 1);
     text.setSuperscript(0, 2);
-    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize remained the same');
+    
+    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
     equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
-    equal(text.styles[0][1].fontSize, size * schema.size, 'character 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * schema.baseline, 'character 1: deltaY has been set');
+    equal(text.styles[0][1].fontSize, size * scale, 'character 1: fontSize has been set');
+    equal(text.styles[0][1].deltaY, size * shift, 'character 1: deltaY has been set');
 
-    equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize was reduced from the style one');
-    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been incremented');
+    equal(text.styles[0][2].fontSize, styleFontSize * scale, 'character 2: fontSize has been decreased');
+    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * shift, 'character 2: deltaY has been decreased');
   });
 
-  test('text subscript - single char', function() {
+  test('text subscript', function() {
     var text = new fabric.Text('xxx', { styles: {
       0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
     } });
+    ok(typeof text.setSuperscript === 'function');
+
     var size = text.fontSize;
-    var schema = text.subscript;
+    var scale = text.downsizing[0];
+    var shift = text.baselineShift[1];
     var styleFontSize = text.styles[0][2].fontSize;
     var styleDeltaY = text.styles[0][2].deltaY;
-
-    ok(typeof text.setSuperscript === 'function');
-    text.setSubscript(0, 1);
     text.setSubscript(0, 2);
-    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize remained the same');
+    text.setSubscript(0, 1);
+
+    equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
     equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
-    equal(text.styles[0][1].fontSize, size * schema.size, 'character 1: fontSize was reduced');
-    equal(text.styles[0][1].deltaY, size * schema.baseline, 'character 1: deltaY has been set');
+    equal(text.styles[0][1].fontSize, size * scale, 'character 1: fontSize has been set');
+    equal(text.styles[0][1].deltaY, size * shift, 'character 1: deltaY has been set');
 
-    equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize was reduced from the style one');
-    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been incremented');
+    equal(text.styles[0][2].fontSize, styleFontSize * scale, 'character 2: fontSize has been decreased');
+    equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * shift, 'character 2: deltaY has been increased');
   });
 
 })();


### PR DESCRIPTION
new properties: `downsizing` and `baselineShift`; `_renderTextDecoration` and `renderCursor` take `deltaY` into account; updated tests;
the result: <img align="middle" src="https://user-images.githubusercontent.com/8561801/29616983-e83c6bb0-881b-11e7-8a63-590d4a5acf49.png"/>
