### PR TITLE
Fix group canvas propagation to sub objects

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -179,6 +179,7 @@
     _onObjectAdded: function(object) {
       this.dirty = true;
       object.group = this;
+      object._set('canvas', this.canvas);
     },
 
     /**
@@ -197,6 +198,12 @@
       if (this.useSetOnGroup) {
         while (i--) {
           this._objects[i].setOnGroup(key, value);
+        }
+      }
+      if (key === 'canvas') {
+        i = this._objects.length;
+        while (i--) {
+          this._objects[i]._set(key, value);
         }
       }
       this.callSuper('_set', key, value);

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -687,6 +687,42 @@
     equal(inspectKey, 'fill', 'setOnGroup has been called');
     equal(inspectValue, 'red', 'setOnGroup has been called');
   });
+
+  test('canvas prop propagation with set', function() {
+    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        group = new fabric.Group([rect1, rect2]);
+
+    group.set('canvas', 'a-canvas');
+    equal(group.canvas, 'a-canvas', 'canvas has been set');
+    equal(group._objects[0].canvas, 'a-canvas', 'canvas has been set on object 0');
+    equal(group._objects[1].canvas, 'a-canvas', 'canvas has been set on object 1');
+  });
+
+  test('canvas prop propagation with add', function() {
+    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        group = new fabric.Group([rect1, rect2]);
+
+    canvas.add(group);
+    equal(group.canvas, canvas, 'canvas has been set');
+    equal(group._objects[0].canvas, canvas, 'canvas has been set on object 0');
+    equal(group._objects[1].canvas, canvas, 'canvas has been set on object 1');
+  });
+
+  test('canvas prop propagation with add to group', function() {
+    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: true}),
+        group = new fabric.Group();
+
+    canvas.add(group);
+    equal(group.canvas, canvas, 'canvas has been set');
+    group.add(rect1)
+    equal(group._objects[0].canvas, canvas, 'canvas has been set on object 0');
+    group.addWithUpdate(rect2)
+    equal(group._objects[1].canvas, canvas, 'canvas has been set on object 0');
+  });
+
   // asyncTest('cloning group with image', function() {
   //   var rect = new fabric.Rect({ top: 100, left: 100, width: 30, height: 10 }),
   //       img = new fabric.Image(_createImageElement()),

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -717,9 +717,9 @@
 
     canvas.add(group);
     equal(group.canvas, canvas, 'canvas has been set');
-    group.add(rect1)
+    group.add(rect1);
     equal(group._objects[0].canvas, canvas, 'canvas has been set on object 0');
-    group.addWithUpdate(rect2)
+    group.addWithUpdate(rect2);
     equal(group._objects[1].canvas, canvas, 'canvas has been set on object 0');
   });
 


### PR DESCRIPTION
It was wrongly removed with transition to ActiveSelection