### PR TITLE
fix dataurl and improve docs for move forward/backward

### DIFF
--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -170,10 +170,11 @@
         strokeLineCap: this.strokeLineCap,
         strokeLineJoin: this.strokeLineJoin,
         strokeDashArray: this.strokeDashArray,
-        originX: 'center',
-        originY: 'center'
       });
-
+      if (path.originX !== 'left' || path.originY !== 'top') {
+        var position = new fabric.Point({ x: path.left, y: path.top });
+        position = path.translateToGivenOrigin(position, 'left', 'top', path.originX, path.originY);
+      }
       if (this.shadow) {
         this.shadow.affectStroke = true;
         path.setShadow(this.shadow);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -825,9 +825,6 @@
      */
     renderAll: function () {
       var canvasToDrawOn = this.contextContainer;
-      if (this.isRendering) {
-        fabric.util.cancelAnimFrame(this.isRendering);
-      }
       this.renderCanvas(canvasToDrawOn, this._objects);
       return this;
     },
@@ -882,6 +879,10 @@
      * @chainable
      */
     renderCanvas: function(ctx, objects) {
+      if (this.isRendering) {
+        fabric.util.cancelAnimFrame(this.isRendering);
+        this.isRendering = 0;
+      }
       this.calcViewportBoundaries();
       this.clearContext(ctx);
       this.fire('before:render');
@@ -1497,6 +1498,10 @@
 
     /**
      * Moves an object or a selection down in stack of drawn objects
+     * An optional paramter, intersecting allowes to move the object in behind
+     * the first intersecting object. Where intersection is calculated with
+     * bounding box. If no intersection is found, there will not be change in the
+     * stack.
      * @param {fabric.Object} object Object to send
      * @param {Boolean} [intersecting] If `true`, send object behind next lower intersecting object
      * @return {fabric.Canvas} thisArg
@@ -1566,6 +1571,10 @@
 
     /**
      * Moves an object or a selection up in stack of drawn objects
+     * An optional paramter, intersecting allowes to move the object in front
+     * of the first intersecting object. Where intersection is calculated with
+     * bounding box. If no intersection is found, there will not be change in the
+     * stack.
      * @param {fabric.Object} object Object to send
      * @param {Boolean} [intersecting] If `true`, send object in front of next upper intersecting object
      * @return {fabric.Canvas} thisArg


### PR DESCRIPTION
close #4217 
close #4213 
close #4201 

The dataurl issue was from the cancelling of renderall request.
The request was cancelled, but the flag was not set to empty.
At that point the next request after the dataurl was not quequed because the flag was indicating that one was already in progress.ix 

Fix free drawing. Created path are created top left positioned and then translated where needed