### PR TITLE
Enlarged hiddenTextarea font size to prevent iOS's input zoom

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -13,7 +13,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea.setAttribute('wrap', 'off');
     var style = this._calcTextareaPosition();
     this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + style.top +
-    '; left: ' + style.left + '; z-index: -999; opacity: 0; width: 1px; height: 1px; font-size: 1px;' +
+    '; left: ' + style.left + '; z-index: -999; opacity: 0; width: 1px; height: 1px; font-size: 16px;' +
     ' line-height: 1px; paddingｰtop: ' + style.fontSize + ';';
     fabric.document.body.appendChild(this.hiddenTextarea);
 


### PR DESCRIPTION

The Problem
====
My canvas is zooming in on mobile (iOS) when I edit an `iText` object.

A good explanation of what is happening and why this is happening can be explained by the following:

> Whether you agree or disagree, Apple decided that form input on iOS needed to be a comfortable reading size, set at a minimum of 16px. If your form field font-size is less than that, they will automatically zoom into the field until the text appears at that size.

The `hiddenTextarea` within the `iText` object is assigned a `font-size` of `1px` which is causing this to zoom action happen. 

Obviously these picture aren't what are happening with the canvas itself, but a great representation of the action that is causing my headache.


----

##### Pics and quote are taken from [this link](https://uxcellence.com/2014/fix-ios-input-zoom).


![lame_zoom](https://user-images.githubusercontent.com/6516452/29643339-511e671c-8823-11e7-8cc1-b7f226bf3811.gif)

----

The solution
====

Increase the `font-size` attribute on the `hiddenTextarea` within the `iText` object from `1px` to  `16px`

Although the `textarea` element isn't visible, the zooming action still occurs. By setting the hidden textarea to a larger size the zooming action doesn't occur and we are all happy-coders.

----

![no_zoom](https://user-images.githubusercontent.com/6516452/29643340-511ecb44-8823-11e7-90f5-345d621205c1.gif)

----
