### PR TITLE
Fix free drawing, fix minScaleLimit for textbox

### DIFF
--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -171,10 +171,10 @@
         strokeLineJoin: this.strokeLineJoin,
         strokeDashArray: this.strokeDashArray,
       });
-      if (path.originX !== 'left' || path.originY !== 'top') {
-        var position = new fabric.Point({ x: path.left, y: path.top });
-        position = path.translateToGivenOrigin(position, 'left', 'top', path.originX, path.originY);
-      }
+      var position = new fabric.Point(path.left + path.width / 2, path.top + path.height / 2);
+      position = path.translateToGivenOrigin(position, 'center', 'center', path.originX, path.originY);
+      path.top = position.y;
+      path.left = position.x;
       if (this.shadow) {
         this.shadow.affectStroke = true;
         path.setShadow(this.shadow);

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -313,6 +313,9 @@
           return this.minScaleLimit;
         }
       }
+      else if (value === 0) {
+        return 0.0001;
+      }
       return value;
     },
 

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -323,16 +323,8 @@
      * @chainable
      */
     scale: function(value) {
-      value = this._constrainScale(value);
-
-      if (value < 0) {
-        this.flipX = !this.flipX;
-        this.flipY = !this.flipY;
-        value *= -1;
-      }
-
-      this.scaleX = value;
-      this.scaleY = value;
+      this._set('scaleX', value);
+      this._set('scaleY', value);
       return this.setCoords();
     },
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -907,10 +907,6 @@
         this.group.set('dirty', true);
       }
 
-      if (key === 'width' || key === 'height') {
-        this.minScaleLimit = Math.min(0.1, 1 / Math.max(this.width, this.height));
-      }
-
       return this;
     },
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -360,7 +360,7 @@
      * @type Number
      * @default
      */
-    minScaleLimit:            0.01,
+    minScaleLimit:            0,
 
     /**
      * When set to `false`, an object can not be selected for modification (using either point-click-based or group-based selection).

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -106,23 +106,6 @@
     equal(cObj.set('opacity', 0.5), cObj, 'chainable');
   });
 
-  test('set and minScaleLimit', function() {
-    var cObj = new fabric.Object({ left: 11, top: 22, width: 50, height: 60, opacity: 0.7 });
-
-    //the min scale limit is given by height.
-    equal(cObj.minScaleLimit.toFixed(3), 0.017);
-
-    cObj.set('width', 1000);
-    equal(cObj.width, 1000);
-    //the min scale limit is given by width.
-    equal(cObj.minScaleLimit, 0.001);
-
-    cObj.set('width', 1);
-    equal(cObj.width, 1);
-    //the min scale limit is given by height.
-    equal(cObj.minScaleLimit.toFixed(3), 0.017);
-  });
-
   test('set with object of prop/values', function() {
     var cObj = new fabric.Object({  });
 

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -389,6 +389,13 @@
   test('_constrainScale', function(){
     var cObj = new fabric.Object({ width: 10, height: 15, strokeWidth: 0 });
     ok(typeof cObj._constrainScale == 'function', '_constrainScale should exist');
+    cObj.set('scaleX', 0);
+    equal(cObj.scaleX, 0.0001);
+    cObj.set('scaleY', 0);
+    equal(cObj.scaleY, 0.0001);
+    cObj.minScaleLimit = 3;
+    cObj.set('scaleY', 0);
+    equal(cObj.scaleY, 3);
   });
 
   test('getCoords return coordinate of object in canvas coordinate.', function() {


### PR DESCRIPTION
close #4223
close #4248

The code i pushed up for free drawing was not working.
What i did was ok for path with very small strokeWidth but not the one with larger.

Also remove the automatic reset of minScaleLimit since it really makes no sense.
If a user set scaleLimit to a value that should be.

There is no way to set scale to 0 with a division ( i cannot think of a division that returns 0 )
If a dev set scale to 0 with its own hands will just generate an error.

if a setter is used to make scale = 0, a safe value of 0.0001 will be set.
