### PR TITLE
fix typo in shadow docs

### DIFF
--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -61,7 +61,7 @@
 
     /**
      * Constructor
-     * @param {Object|String} [options] Options object with any of color, blur, offsetX, offsetX properties or string (e.g. "rgba(0,0,0,0.2) 2px 2px 10px, "2px 2px 10px rgba(0,0,0,0.2)")
+     * @param {Object|String} [options] Options object with any of color, blur, offsetX, offsetY properties or string (e.g. "rgba(0,0,0,0.2) 2px 2px 10px")
      * @return {fabric.Shadow} thisArg
      */
     initialize: function(options) {


### PR DESCRIPTION
Changed "offsetX offsetX" to "offsetX offsetY".
The second change was because of a missing end-quote, however one example should be enough and less confusing.