### PR TITLE
If modifyng the active selection, modify also the hovered target

### DIFF
--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -50,6 +50,7 @@
       var activeSelection = this._activeObject;
       if (activeSelection.contains(target)) {
         activeSelection.removeWithUpdate(target);
+        this._hoveredTarget = target;
         if (activeSelection.size() === 1) {
           // activate last remaining object
           this.setActiveObject(activeSelection.item(0), e);
@@ -58,6 +59,7 @@
       }
       else {
         activeSelection.addWithUpdate(target);
+        this._hoveredTarget = activeSelection;
       }
       this.fire('selection:created', { target: activeSelection, e: e });
     },


### PR DESCRIPTION
If we are shift clicking somethig, we are hovering it.
At that point if it enters or exit an active selection, the hovered target changes, but the reference to the latest hovered tharget does not.
We update the reference manually to do not fire extra events.
