### PR TITLE
fix object.getObjectOpacity() docs

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -858,7 +858,7 @@
 
     /**
      * Return the object opacity counting also the group property
-     * @return {Object} object with scaleX and scaleY properties
+     * @return {Number}
      */
     getObjectOpacity: function() {
       var opacity = this.opacity;


### PR DESCRIPTION
Seems like a copy&paste leftover.