### PR TITLE
Compare distance between cursor with absolute value.

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -197,10 +197,12 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    */
   _getNewSelectionStartFromOffset: function(mouseOffset, prevWidth, width, index, jlen) {
     // we need Math.abs because when width is after the last char, the offset is given as 1, while is 0
-    var distanceBtwLastCharAndCursor = Math.abs(mouseOffset.x - prevWidth),
-        distanceBtwNextCharAndCursor = Math.abs(width - mouseOffset.x),
-        offset = distanceBtwNextCharAndCursor > distanceBtwLastCharAndCursor ? 0 : 1,
+    var distanceBtwLastCharAndCursor = mouseOffset.x - prevWidth,
+        distanceBtwNextCharAndCursor = width - mouseOffset.x,
+        offset = distanceBtwNextCharAndCursor > distanceBtwLastCharAndCursor ||
+          distanceBtwNextCharAndCursor < 0 ? 0 : 1,
         newSelectionStart = index + offset;
+        console.log(offset)
     // if object is horizontally flipped, mirror cursor location from the end
     if (this.flipX) {
       newSelectionStart = jlen - newSelectionStart;

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -202,7 +202,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         offset = distanceBtwNextCharAndCursor > distanceBtwLastCharAndCursor ||
           distanceBtwNextCharAndCursor < 0 ? 0 : 1,
         newSelectionStart = index + offset;
-        console.log(offset)
     // if object is horizontally flipped, mirror cursor location from the end
     if (this.flipX) {
       newSelectionStart = jlen - newSelectionStart;

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -196,9 +196,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @private
    */
   _getNewSelectionStartFromOffset: function(mouseOffset, prevWidth, width, index, jlen) {
-
-    var distanceBtwLastCharAndCursor = mouseOffset.x - prevWidth,
-        distanceBtwNextCharAndCursor = width - mouseOffset.x,
+    // we need Math.abs because when width is after the last char, the offset is given as 1, while is 0
+    var distanceBtwLastCharAndCursor = Math.abs(mouseOffset.x - prevWidth),
+        distanceBtwNextCharAndCursor = Math.abs(width - mouseOffset.x),
         offset = distanceBtwNextCharAndCursor > distanceBtwLastCharAndCursor ? 0 : 1,
         newSelectionStart = index + offset;
     // if object is horizontally flipped, mirror cursor location from the end

--- a/test.js
+++ b/test.js
@@ -39,6 +39,7 @@ testrunner.run({
       './test/unit/object_geometry.js',
       './test/unit/object_origin.js',
       './test/unit/itext.js',
+      './test/unit/itext_click_behaviour.js',
       './test/unit/itext_key_behaviour.js',
       './test/unit/collection.js',
       './test/unit/point.js',

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -3,28 +3,28 @@
     var iText = new fabric.IText('test need some word\nsecond line');
     var index = 10;
     var jlen = 20;
-    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen)
-    equal(selection, index, 'index value did not change')
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen);
+    equal(selection, index, 'index value did not change');
   });
   test('_getNewSelectionStartFromOffset middle of line', function() {
     var iText = new fabric.IText('test need some word\nsecond line');
     var index = 10;
     var jlen = 20;
-    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 519 }, 500, 520, index, jlen)
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 519 }, 500, 520, index, jlen);
     equal(selection, index + 1, 'index value was moved to next char, since is very near');
   });
   test('_getNewSelectionStartFromOffset middle of line', function() {
     var iText = new fabric.IText('test need some word\nsecond line');
     var index = 10;
     var jlen = 20;
-    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 511 }, 500, 520, index, jlen)
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 511 }, 500, 520, index, jlen);
     equal(selection, index, 'index value was NOT moved to next char, since is very near');
   });
   test('_getNewSelectionStartFromOffset middle of line', function() {
     var iText = new fabric.IText('test need some word\nsecond line');
     var index = 10;
     var jlen = 10;
-    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen)
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen);
     equal(selection, index, 'index value was NOT moved to next char, since is already at end of text');
   });
-})
+})();

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -17,8 +17,8 @@
     var iText = new fabric.IText('test need some word\nsecond line');
     var index = 10;
     var jlen = 20;
-    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 511 }, 500, 520, index, jlen);
-    equal(selection, index, 'index value was NOT moved to next char, since is very near');
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 502 }, 500, 520, index, jlen);
+    equal(selection, index, 'index value was NOT moved to next char, since is very near to first one');
   });
   test('_getNewSelectionStartFromOffset middle of line', function() {
     var iText = new fabric.IText('test need some word\nsecond line');

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -1,0 +1,30 @@
+(function(){
+  test('_getNewSelectionStartFromOffset end of line', function() {
+    var iText = new fabric.IText('test need some word\nsecond line');
+    var index = 10;
+    var jlen = 20;
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen)
+    equal(selection, index, 'index value did not change')
+  });
+  test('_getNewSelectionStartFromOffset middle of line', function() {
+    var iText = new fabric.IText('test need some word\nsecond line');
+    var index = 10;
+    var jlen = 20;
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 519 }, 500, 520, index, jlen)
+    equal(selection, index + 1, 'index value was moved to next char, since is very near');
+  });
+  test('_getNewSelectionStartFromOffset middle of line', function() {
+    var iText = new fabric.IText('test need some word\nsecond line');
+    var index = 10;
+    var jlen = 20;
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 511 }, 500, 520, index, jlen)
+    equal(selection, index, 'index value was NOT moved to next char, since is very near');
+  });
+  test('_getNewSelectionStartFromOffset middle of line', function() {
+    var iText = new fabric.IText('test need some word\nsecond line');
+    var index = 10;
+    var jlen = 10;
+    var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen)
+    equal(selection, index, 'index value was NOT moved to next char, since is already at end of text');
+  });
+})


### PR DESCRIPTION
When cursor is after the end of line, we cannot use the calculation as if the cursor was between 2 chars.
The cursor is after both of them and so we need to compare the distance in absolute value.

@blobinabottle that should fix the cursor to next line.
(not tried yet)