### PR TITLE
Fix IE rendering of SVG as overlay image

### DIFF
--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -341,11 +341,16 @@
       div.style.position = 'absolute';
       div.appendChild(img);
       document.querySelector('body').appendChild(div);
-      img.onload = setTimeout(function () {
+      /**
+       * Wrap in function to:
+       *   1. Call existing callback
+       *   2. Cleanup DOM
+       */
+      img.onload = function () {
         onLoadCallback();
         div.parentNode.removeChild(div);
         div = null;
-      }, 1);
+      };
     },
 
     /**

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -296,8 +296,23 @@
 
       /** @ignore */
       img.onload = function () {
-        callback && callback.call(context, img);
-        img = img.onload = img.onerror = null;
+        // ugly fix for IE11; IE11 will only render data-url SVG if visible in DOM
+        // so we create a div (1x1px at -1,-1px) containing the img.
+        if(img.src.substr(0,5) == 'data:'){
+          var div = document.createElement('div');
+          div.style.width = div.style.height = '1px';
+          div.style.left = div.style.right = '-1px';
+          div.style.position = 'absolute';
+          div.appendChild(img)
+          document.querySelector("body").appendChild(div)
+          setTimeout(function(){
+            callback && callback.call(context, img);
+            div = img = img.onload = img.onerror = null;
+          }, 1)  
+        } else {
+          callback && callback.call(context, img);
+          img = img.onload = img.onerror = null;
+        }
       };
 
       /** @ignore */

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -335,12 +335,12 @@
      * @return {Object} DOM element (div containing the SVG image)
      */
     loadImageInDom: function(img, onLoadCallback) {
-      var div = document.createElement('div');
+      var div = fabric.document.createElement('div');
       div.style.width = div.style.height = '1px';
       div.style.left = div.style.top = '-100%';
       div.style.position = 'absolute';
       div.appendChild(img);
-      document.querySelector('body').appendChild(div);
+      fabric.document.querySelector('body').appendChild(div);
       /**
        * Wrap in function to:
        *   1. Call existing callback

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -309,7 +309,8 @@
             callback && callback.call(context, img);
             div = img = img.onload = img.onerror = null;
           }, 1);
-        } else {
+        }
+        else {
           callback && callback.call(context, img);
           img = img.onload = img.onerror = null;
         }

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -298,17 +298,17 @@
       img.onload = function () {
         // ugly fix for IE11; IE11 will only render data-url SVG if visible in DOM
         // so we create a div (1x1px at -1,-1px) containing the img.
-        if(img.src.substr(0,5) == 'data:'){
+        if (img.src.substr(0,5) === 'data:') {
           var div = document.createElement('div');
           div.style.width = div.style.height = '1px';
           div.style.left = div.style.right = '-1px';
           div.style.position = 'absolute';
-          div.appendChild(img)
-          document.querySelector("body").appendChild(div)
+          div.appendChild(img);
+          document.querySelector('body').appendChild(div);
           setTimeout(function(){
             callback && callback.call(context, img);
             div = img = img.onload = img.onerror = null;
-          }, 1)  
+          }, 1);
         } else {
           callback && callback.call(context, img);
           img = img.onload = img.onerror = null;

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -296,19 +296,11 @@
 
       /** @ignore */
       img.onload = function () {
-        // ugly fix for IE11; IE11 will only render data-url SVG if visible in DOM
-        // so we create a div (1x1px at -1,-1px) containing the img.
-        if (img.src.substr(0,5) === 'data:') {
-          var div = document.createElement('div');
-          div.style.width = div.style.height = '1px';
-          div.style.left = div.style.right = '-1px';
-          div.style.position = 'absolute';
-          div.appendChild(img);
-          document.querySelector('body').appendChild(div);
-          setTimeout(function(){
-            callback && callback.call(context, img);
-            div = img = img.onload = img.onerror = null;
-          }, 1);
+        if (img.src.substring(0,14) === 'data:image/svg') {
+          // IE10 / IE11-Fix: SVG contents from data: URI
+          // will only be available if the IMG is present
+          // in the DOM (and visible)
+          fabric.util.loadImageInDom(img, callback, context);
         }
         else {
           callback && callback.call(context, img);
@@ -332,6 +324,27 @@
       }
 
       img.src = url;
+    },
+
+    /**
+     * Attaches SVG image with data: URL to the dom
+     * @memberOf fabric.util
+     * @param {Object} img Image object with data:image/svg src
+     * @param {Function} callback Callback; invoked with loaded image
+     * @param {*} [context] Context to invoke callback in
+     */
+    loadImageInDom: function(img, callback, context) {
+      var div = document.createElement('div');
+      div.style.width = div.style.height = '1px';
+      div.style.left = div.style.top = '-100%';
+      div.style.position = 'absolute';
+      div.appendChild(img);
+      document.querySelector('body').appendChild(div);
+      setTimeout(function(){
+        callback && callback.call(context, img);
+        div.parentNode.removeChild(div);
+        div = img = img.onload = img.onerror = null;
+      }, 1);
     },
 
     /**


### PR DESCRIPTION
IE11 (and sometimes IE10, timing issue) won't "in memory render" SVG images when the source is a data:... URI, if the img-element isn't present and visible in the DOM. Even when appending the IMG to the DOM with `display: none` or something like that, the img will be 0x0 px.

This ugly-ass fix will create a div at -1px -1px (absolute) and append the img in this div. After this, de callback will be able to get the image contents.

You can reproduce the problem in IE11 by using a data:... URI to use a SVG for `fabric.Image.fromURL` (to use it as an overlay with `canvas.setOverlayImage`). 

With this fix, this works fine :)