### PR TITLE
Fix lockScalingFlip + flip

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -879,8 +879,8 @@
       var dist = localMouse.y + localMouse.x,
           lastDist = _dim.y * transform.original.scaleY / target.scaleY +
                      _dim.x * transform.original.scaleX / target.scaleX,
-          scaled, signX = localMouse.x / Math.abs(localMouse.x),
-          signY = localMouse.y / Math.abs(localMouse.y);
+          scaled, signX = localMouse.x < 0 ? -1 : 1,
+          signY = localMouse.y < 0 ? -1 : 1;
 
       // We use transform.scaleX/Y instead of target.scaleX/Y
       // because the object may have a min scale and we'll loose the proportions


### PR DESCRIPTION
There was a triggered division by 0 and NaN scale when lockScalingFlip + scaleEqually were used togheter.

closes #4325 

@blobinabottle