### PR TITLE
Fix fast type in itext.

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -478,6 +478,9 @@
       }
       this.cursorOffsetCache = { };
       this.text = this.hiddenTextarea.value;
+      if (this._shouldClearDimensionCache()) {
+        this.initDimensions();
+      }
       var newSelection = this.fromStringToGraphemeSelection(
         this.hiddenTextarea.selectionStart, this.hiddenTextarea.selectionEnd, this.hiddenTextarea.value);
       this.selectionEnd = this.selectionStart = newSelection.selectionEnd;

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -154,6 +154,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         this.canvas.fire('text:changed', { target: this });
         this.canvas.requestRenderAll();
       }
+      return;
     }
 
     if (this.selectionStart !== this.selectionEnd) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -316,9 +316,10 @@
     _splitText: function() {
       var newLines = this._splitTextIntoLines(this.text);
       this.textLines = newLines.lines;
-      this._unwrappedTextLines = newLines._unwrappedLines;
       this._textLines = newLines.graphemeLines;
+      this._unwrappedTextLines = newLines._unwrappedLines;
       this._text = newLines.graphemeText;
+      return newLines;
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -310,6 +310,18 @@
     },
 
     /**
+     * @private
+     * Divides text into lines of text and lines of graphemes.
+     */
+    _splitText: function() {
+      var newLines = this._splitTextIntoLines(this.text);
+      this.textLines = newLines.lines;
+      this._unwrappedTextLines = newLines._unwrappedLines;
+      this._textLines = newLines.graphemeLines;
+      this._text = newLines.graphemeText;
+    },
+
+    /**
      * Initialize or update text dimensions.
      * Updates this.width and this.height with the proper values.
      * Does not return dimensions.
@@ -318,11 +330,7 @@
       if (this.__skipDimension) {
         return;
       }
-      var newLines = this._splitTextIntoLines(this.text);
-      this.textLines = newLines.lines;
-      this._unwrappedTextLines = newLines._unwrappedLines;
-      this._textLines = newLines.graphemeLines;
-      this._text = newLines.graphemeText;
+      this._splitText();
       this._clearCache();
       this.width = this.calcTextWidth() || this.cursorWidth || MIN_TEXT_WIDTH;
       if (this.textAlign === 'justify') {

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -89,12 +89,7 @@
       // clear dynamicMinWidth as it will be different after we re-wrap line
       this.dynamicMinWidth = 0;
       // wrap lines
-      var newText = this._splitTextIntoLines(this.text);
-      this.textLines = newText.lines;
-      this._textLines = newText.graphemeLines;
-      this._unwrappedTextLines = newText._unwrappedLines;
-      this._text = newText.graphemeText;
-      this._styleMap = this._generateStyleMap(newText);
+      this._styleMap = this._generateStyleMap(this._splitText());
       // if after wrapping, the width is smaller than dynamicMinWidth, change the width and re-wrap
       if (this.dynamicMinWidth > this.width) {
         this._set('width', this.dynamicMinWidth);

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -503,6 +503,15 @@
     assert.deepEqual(iText.getStyleAtPosition(18), { fill: 'green' });
   });
 
+  QUnit.test('_splitText', function(assert) {
+    var text = new fabric.Text('test foo bar-baz\nqux', {});
+    var test = text._splitText();
+    assert.equal(test.lines[0], 'test foo bar-baz', 'first line is correct');
+    assert.equal(test.lines[1], 'qux', 'second line is correct');
+    assert.equal(test.graphemeLines[0], 'test foo bar-baz', 'first line is correct');
+    assert.equal(test.graphemeLines[1], 'qux', 'second line is correct');
+  });
+
   QUnit.test('getStyleAtPosition complete', function(assert) {
     var iText = new fabric.Text('test foo bar-baz\nqux', {
       styles: {

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -508,8 +508,8 @@
     var test = text._splitText();
     assert.equal(test.lines[0], 'test foo bar-baz', 'first line is correct');
     assert.equal(test.lines[1], 'qux', 'second line is correct');
-    assert.equal(test.graphemeLines[0], 'test foo bar-baz', 'first line is correct');
-    assert.equal(test.graphemeLines[1], 'qux', 'second line is correct');
+    assert.deepEqual(test.graphemeLines[0], ['t','e','s','t',' ','f','o','o',' ','b','a','r','-','b','a','z'], 'first line is correct');
+    assert.deepEqual(test.graphemeLines[1], ['q','u','x'], 'second line is correct');
   });
 
   QUnit.test('getStyleAtPosition complete', function(assert) {


### PR DESCRIPTION
A render could start while a textarea update was in progress, creating problems to style.
Forcing dimension check and calculation immediately after the event, execute some extra work ( that would have been executed at next render anyway ) and looks like it is fixing the problem.

close #4335 
@blobinabottle