### PR TITLE
isTargetTransparent fixes && cachedCanvas

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -480,8 +480,9 @@
       var ctx = this.contextCache,
           originalColor = target.selectionBackgroundColor;
 
-      target.hasBorders = target.transparentCorners = false;
       target.selectionBackgroundColor = '';
+
+      this.clearContext(ctx);
 
       ctx.save();
       ctx.transform.apply(ctx, this.viewportTransform);
@@ -491,14 +492,14 @@
       target === this._activeObject && target._renderControls(ctx, {
         hasBorders: false,
         transparentCorners: false
+      }, {
+        hasBorders: false,
       });
 
       target.selectionBackgroundColor = originalColor;
 
       var isTransparent = fabric.util.isTransparent(
         ctx, x, y, this.targetFindTolerance);
-
-      this.clearContext(ctx);
 
       return isTransparent;
     },

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -981,6 +981,7 @@
         this.drawCacheOnCanvas(ctx);
       }
       else {
+        this._cacheCanvas = null;
         this.dirty = false;
         this.drawObject(ctx);
         if (this.objectCaching && this.statefullCache) {


### PR DESCRIPTION
fixes problems with isTargetTransparent targeting. also nulls out cachedCanvas when not being used to make it easier to check if a proper cachedCanvas exists