### PR TITLE
Added a justify-left option for text alignment

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -148,7 +148,7 @@
     linethrough:       false,
 
     /**
-     * Text alignment. Possible values: "left", "center", "right" or "justify".
+     * Text alignment. Possible values: "left", "center", "right", "justify" or "justify-left".
      * @type String
      * @default
      */
@@ -334,8 +334,8 @@
       this._splitText();
       this._clearCache();
       this.width = this.calcTextWidth() || this.cursorWidth || MIN_TEXT_WIDTH;
-      if (this.textAlign === 'justify') {
-        // once text is misured we need to make space fatter to make justified text.
+      if (this.textAlign.indexOf('justify') !== -1) {
+        // once text is measured we need to make space fatter to make justified text.
         this.enlargeSpaces();
       }
       this.height = this.calcTextHeight();
@@ -347,22 +347,24 @@
     enlargeSpaces: function() {
       var diffSpace, currentLineWidth, numberOfSpaces, accumulatedSpace, line, charBound, spaces;
       for (var i = 0, len = this._textLines.length; i < len; i++) {
-        accumulatedSpace = 0;
-        line = this._textLines[i];
-        currentLineWidth = this.getLineWidth(i);
-        if (currentLineWidth < this.width && (spaces = this.textLines[i].match(this._reSpacesAndTabs))) {
-          numberOfSpaces = spaces.length;
-          diffSpace = (this.width - currentLineWidth) / numberOfSpaces;
-          for (var j = 0, jlen = line.length; j <= jlen; j++) {
-            charBound = this.__charBounds[i][j];
-            if (this._reSpaceAndTab.test(line[j])) {
-              charBound.width += diffSpace;
-              charBound.kernedWidth += diffSpace;
-              charBound.left += accumulatedSpace;
-              accumulatedSpace += diffSpace;
-            }
-            else {
-              charBound.left += accumulatedSpace;
+        if (this.textAlign === 'justify' || this._textLineBreaks.indexOf(i) === -1) {
+          accumulatedSpace = 0;
+          line = this._textLines[i];
+          currentLineWidth = this.getLineWidth(i);
+          if (currentLineWidth < this.width && (spaces = this.textLines[i].match(this._reSpacesAndTabs))) {
+            numberOfSpaces = spaces.length;
+            diffSpace = (this.width - currentLineWidth) / numberOfSpaces;
+            for (var j = 0, jlen = line.length; j <= jlen; j++) {
+              charBound = this.__charBounds[i][j];
+              if (this._reSpaceAndTab.test(line[j])) {
+                charBound.width += diffSpace;
+                charBound.kernedWidth += diffSpace;
+                charBound.left += accumulatedSpace;
+                accumulatedSpace += diffSpace;
+              }
+              else {
+                charBound.left += accumulatedSpace;
+              }
             }
           }
         }
@@ -854,7 +856,7 @@
           left += charBox.kernedWidth - charBox.width;
         }
         boxWidth += charBox.kernedWidth;
-        if (this.textAlign === 'justify' && !timeToRender) {
+        if (this.textAlign.indexOf('justify') !== -1 && !timeToRender) {
           if (this._reSpaceAndTab.test(line[i])) {
             timeToRender = true;
           }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -148,7 +148,7 @@
     linethrough:       false,
 
     /**
-     * Text alignment. Possible values: "left", "center", "right", "justify" or "justify-left".
+     * Text alignment. Possible values: "left", "center", "right", "justify" or "justify-wrapped".
      * @type String
      * @default
      */
@@ -347,7 +347,8 @@
     enlargeSpaces: function() {
       var diffSpace, currentLineWidth, numberOfSpaces, accumulatedSpace, line, charBound, spaces;
       for (var i = 0, len = this._textLines.length; i < len; i++) {
-        if (this.textAlign === 'justify' || this._textLineBreaks.indexOf(i) === -1) {
+        if (this.textAlign === 'justify' || !this.hasOwnProperty('_textLineBreaks') ||
+            this._textLineBreaks.indexOf(i) === -1) {
           accumulatedSpace = 0;
           line = this._textLines[i];
           currentLineWidth = this.getLineWidth(i);

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -94,7 +94,7 @@
       if (this.dynamicMinWidth > this.width) {
         this._set('width', this.dynamicMinWidth);
       }
-      if (this.textAlign === 'justify') {
+      if (this.textAlign.indexOf('justify') !== -1) {
         // once text is measured we need to make space fatter to make justified text.
         this.enlargeSpaces();
       }
@@ -233,11 +233,13 @@
      * @returns {Array} Array of lines
      */
     _wrapText: function(lines, desiredWidth) {
-      var wrapped = [], i;
+      var wrapped = [], textLineBreaks = [], i;
       this.isWrapping = true;
       for (i = 0; i < lines.length; i++) {
         wrapped = wrapped.concat(this._wrapLine(lines[i], i, desiredWidth));
+        textLineBreaks[i] = wrapped.length - 1;
       }
+      this._textLineBreaks = textLineBreaks;
       this.isWrapping = false;
       return wrapped;
     },


### PR DESCRIPTION
textAlign: 'justify' gives the default style for justified text, textAlign: 'justify-left' aligns the lines with breaks and the final line to the left.

Replaces https://github.com/kangax/fabric.js/pull/3896, which was based on 1.x