### PR TITLE
object_stacking fix

### DIFF
--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -69,7 +69,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    * @chainable
    */
   moveTo: function(index) {
-    if (this.group) {
+    if (this.group && this.group.type !== 'activeSelection') {
       fabric.StaticCanvas.prototype.moveTo.call(this.group, this, index);
     }
     else {

--- a/test/unit/activeselection.js
+++ b/test/unit/activeselection.js
@@ -237,5 +237,42 @@
     assert.equal(g2.canvas, canvas);
     assert.equal(g2._objects[3].canvas, canvas);
   });
+  
+  QUnit.test('moveTo on activeSelection', function(assert) {
+    var group = makeAsWith4Objects({ canvas: canvas }),
+        groupEl1 = group.getObjects()[0],
+        groupEl2 = group.getObjects()[1],
+        groupEl3 = group.getObjects()[2],
+        groupEl4 = group.getObjects()[3];
+    canvas.add(groupEl1, groupEl2, groupEl3, groupEl4);
+    canvas.setActiveObject(group);
+    assert.ok(typeof group.item(0).moveTo === 'function');
+
+    // [ 1, 2, 3, 4 ]
+    assert.equal(group.item(0), groupEl1, 'actual group position 1');
+    assert.equal(group.item(1), groupEl2, 'actual group position 2');
+    assert.equal(group.item(2), groupEl3, 'actual group position 3');
+    assert.equal(group.item(3), groupEl4, 'actual group position 4');
+    assert.equal(group.item(9999), undefined);
+    assert.equal(canvas.item(0), groupEl1, 'actual canvas position 1');
+    assert.equal(canvas.item(1), groupEl2, 'actual canvas position 2');
+    assert.equal(canvas.item(2), groupEl3, 'actual canvas position 3');
+    assert.equal(canvas.item(3), groupEl4, 'actual canvas position 4');
+    assert.equal(canvas.item(9999), undefined);
+    
+    group.item(0).moveTo(3);
+
+    assert.equal(group.item(0), groupEl1, 'did not change group position 1');
+    assert.equal(group.item(1), groupEl2, 'did not change group position 2');
+    assert.equal(group.item(2), groupEl3, 'did not change group position 3');
+    assert.equal(group.item(3), groupEl4, 'did not change group position 4');
+    assert.equal(group.item(9999), undefined);
+    // moved 1 to level 3 — [2, 3, 4, 1]
+    assert.equal(canvas.item(3), groupEl1, 'item 1 is not at last');
+    assert.equal(canvas.item(0), groupEl2, 'item 2 shifted down to 1');
+    assert.equal(canvas.item(1), groupEl3, 'item 3 shifted down to 2');
+    assert.equal(canvas.item(2), groupEl4, 'item 4 shifted down to 3');
+    assert.equal(canvas.item(9999), undefined);
+  });
 
 })();

--- a/test/unit/activeselection.js
+++ b/test/unit/activeselection.js
@@ -259,7 +259,7 @@
     assert.equal(canvas.item(2), groupEl3, 'actual canvas position 3');
     assert.equal(canvas.item(3), groupEl4, 'actual canvas position 4');
     assert.equal(canvas.item(9999), undefined);
-  
+
     group.item(0).moveTo(3);
 
     assert.equal(group.item(0), groupEl1, 'did not change group position 1');

--- a/test/unit/activeselection.js
+++ b/test/unit/activeselection.js
@@ -237,7 +237,7 @@
     assert.equal(g2.canvas, canvas);
     assert.equal(g2._objects[3].canvas, canvas);
   });
-  
+
   QUnit.test('moveTo on activeSelection', function(assert) {
     var group = makeAsWith4Objects({ canvas: canvas }),
         groupEl1 = group.getObjects()[0],
@@ -259,7 +259,7 @@
     assert.equal(canvas.item(2), groupEl3, 'actual canvas position 3');
     assert.equal(canvas.item(3), groupEl4, 'actual canvas position 4');
     assert.equal(canvas.item(9999), undefined);
-    
+  
     group.item(0).moveTo(3);
 
     assert.equal(group.item(0), groupEl1, 'did not change group position 1');


### PR DESCRIPTION
when calling moveTo on an activeSelection the code should move the objects in the canvas._objects stack instead of moving the objects in the activeObject._objects stack. This already works correctly for moveForward / moveBack / ect.