### PR TITLE
Disable http/https requires for browser builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "canvas": false,
     "fs":      false,
     "jsdom":   false,
+    "http":   false,
+    "https":   false,
     "xmldom":  false
   },
   "repository": {


### PR DESCRIPTION
See https://github.com/kangax/fabric.js/issues/4423

`webpack -p` build just including `fabric` goes from `334kb` to `300kb`.