### PR TITLE
mousemove target and kerning

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -658,7 +658,7 @@
       else {
         this._transformObject(e);
       }
-      this._handleEvent(e, 'move', target);
+      this._handleEvent(e, 'move', this._currentTransform ? null : target);
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -853,8 +853,11 @@
         charBox = this.__charBounds[lineIndex][i];
         if (boxWidth === 0) {
           left += charBox.kernedWidth - charBox.width;
+          boxWidth += charBox.width;
         }
-        boxWidth += charBox.kernedWidth;
+        else {
+          boxWidth += charBox.kernedWidth;
+        }
         if (this.textAlign === 'justify' && !timeToRender) {
           if (this._reSpaceAndTab.test(line[i])) {
             timeToRender = true;


### PR DESCRIPTION
This PR introduces 2 fixes.

1) when drawing a character at start of kerning segment, since we move back the left of the kern difference, use the width, not the kerned width.

2) during mouse move that happen during a transform, do not search for target again, is a loss of time and fabric cannot manage 2 targets at time, in that moment the current target is the transforming target, even if we are hovering some other.