### PR TITLE
fixed group restoring internal absolute coords for subtarget check

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -93,8 +93,22 @@
         delete options.centerPoint;
         this.callSuper('initialize', options);
       }
+      else {
+        this._updateObjectsACoords();
+      }
 
       this.setCoords();
+    },
+
+    /**
+     * @private
+     * @param {Boolean} [skipCoordsChange] if true, coordinates of objects enclosed in a group do not change
+     */
+    _updateObjectsACoords: function() {
+      var ignoreZoom = true, skipAbsolute = true;
+      for (var i = this._objects.length; i--; ){
+        this._objects[i].setCoords(ignoreZoom, skipAbsolute);
+      }
     },
 
     /**

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -392,6 +392,21 @@
     });
   });
 
+  QUnit.test('fromObject restores oCoords', function(assert) {
+    var done = assert.async();
+    var group = makeGroupWith2ObjectsWithOpacity();
+
+    var groupObject = group.toObject();
+
+    fabric.Group.fromObject(groupObject, function(newGroupFromObject) {
+      console.log(newGroupFromObject._objects[0]);
+      assert.ok(newGroupFromObject._objects[0].oCoords.tl, 'acoords 0 are restored');
+      assert.ok(newGroupFromObject._objects[1].oCoords.tl, 'acoords 1 are restored');
+
+      done();
+    });
+  });
+
   QUnit.test('fromObject does not delete objects from source', function(assert) {
     var done = assert.async();
     var group = makeGroupWith2ObjectsWithOpacity();


### PR DESCRIPTION
Group initialized was checking if the group was coming from a OBJECT restore in order to skip some calculation. It was also skipping the absolute coord check, making the sub targeting broken.

close #4444