### PR TITLE
Reduce leaks in NODEJS continue canvas creations

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1538,7 +1538,6 @@
      * @chainable
      */
     dispose: function () {
-      fabric.StaticCanvas.prototype.dispose.call(this);
       var wrapper = this.wrapperEl;
       this.removeListeners();
       wrapper.removeChild(this.upperCanvasEl);
@@ -1548,6 +1547,7 @@
         wrapper.parentNode.replaceChild(this.lowerCanvasEl, this.wrapperEl);
       }
       delete this.wrapperEl;
+      fabric.StaticCanvas.prototype.dispose.call(this);
       return this;
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1664,7 +1664,12 @@
      * @chainable
      */
     dispose: function () {
-      this.clear();
+      this._objects.length = 0;
+      this.backgroundImage = null;
+      this.overlayImage = null;
+      this._iTextInstances = null;
+      this.lowerCanvasEl = null;
+      this.cacheCanvasEl = null;
       return this;
     },
 

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1313,11 +1313,13 @@
     assert.equal(canvas.toString(), '#<fabric.Canvas (1): { objects: 1 }>');
   });
 
-  QUnit.test('dispose', function(assert) {
-    assert.ok(typeof canvas.dispose === 'function');
-    canvas.add(makeRect(), makeRect(), makeRect());
-    canvas.dispose();
-    assert.equal(canvas.getObjects().length, 0, 'dispose should clear canvas');
+  QUnit.test('dispose clear references', function(assert) {
+    var canvas2 = new fabric.Canvas();
+    assert.ok(typeof canvas2.dispose === 'function');
+    canvas2.add(makeRect(), makeRect(), makeRect());
+    canvas2.dispose();
+    assert.equal(canvas2.getObjects().length, 0, 'dispose should clear canvas');
+    assert.equal(canvas2.lowerCanvasEl, null, 'dispose should clear lowerCanvasEl');
   });
 
   QUnit.test('clone', function(assert) {


### PR DESCRIPTION
Create DISPOSE independently of .clear().
Avoid rendering during dispose.

close #4449