### PR TITLE
Add an option to selection objects only when 100% intersect

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -179,6 +179,13 @@
     selectionLineWidth:     1,
 
     /**
+     * Selection only shapes that intersect to 100%
+     * @type Boolean
+     * @default
+     */
+    selectionFullyContained: false,
+
+    /**
      * Default cursor value used when hovering over an object on canvas
      * @type String
      * @default

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -179,7 +179,7 @@
     selectionLineWidth:     1,
 
     /**
-     * Selection only shapes that intersect to 100%
+     * Select only shapes that are fully contained in the dragged selection rectangle.
      * @type Boolean
      * @default
      */

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -124,6 +124,7 @@
           y2 = y1 + this._groupSelector.top,
           selectionX1Y1 = new fabric.Point(min(x1, x2), min(y1, y2)),
           selectionX2Y2 = new fabric.Point(max(x1, x2), max(y1, y2)),
+          allowIntersect = !this.selectionFullyContained,
           isClick = x1 === x2 && y1 === y2;
       // we iterate reverse order to collect top first in case of click.
       for (var i = this._objects.length; i--; ) {
@@ -133,10 +134,10 @@
           continue;
         }
 
-        if ((!this.selectionFullyContained && currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2)) ||
+        if ((allowIntersect && currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2)) ||
             currentObject.isContainedWithinRect(selectionX1Y1, selectionX2Y2) ||
-            (!this.selectionFullyContained && currentObject.containsPoint(selectionX1Y1)) ||
-            (!this.selectionFullyContained && currentObject.containsPoint(selectionX2Y2))
+            (allowIntersect && currentObject.containsPoint(selectionX1Y1)) ||
+            (allowIntersect && currentObject.containsPoint(selectionX2Y2))
         ) {
           group.push(currentObject);
 

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -133,10 +133,10 @@
           continue;
         }
 
-        if (currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2) ||
+        if ((!this.selectionFullyContained && currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2)) ||
             currentObject.isContainedWithinRect(selectionX1Y1, selectionX2Y2) ||
-            currentObject.containsPoint(selectionX1Y1) ||
-            currentObject.containsPoint(selectionX2Y2)
+            (!this.selectionFullyContained && currentObject.containsPoint(selectionX1Y1)) ||
+            (!this.selectionFullyContained && currentObject.containsPoint(selectionX2Y2))
         ) {
           group.push(currentObject);
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -572,24 +572,6 @@
     canvas.selectionFullyContained = false;
   });
 
-  QUnit.test('_collectObjects does not collect object if objects are not fully contained inside', function(assert) {
-    canvas.selectionFullyContained = true;
-    var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
-    var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 10 });
-    var rect3 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 0 });
-    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
-    canvas.add(rect1, rect2, rect3, rect4);
-    canvas._groupSelector = {
-      top: 20,
-      left: 20,
-      ex: 0,
-      ey: 0
-    };
-    var collected = canvas._collectObjects();
-    assert.equal(collected.length, 0, 'a rect not fully including objects do not collect any of them');
-    canvas.selectionFullyContained = false;
-  });
-
   QUnit.test('_fireSelectionEvents fires multiple things', function(assert) {
     var rect1Deselected = false;
     var rect3Selected = false;

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -531,6 +531,65 @@
     assert.equal(collected[2], rect1, 'rect1 is collected');
   });
 
+  QUnit.test('_collectObjects collects object fully contained in area', function(assert) {
+    canvas.selectionFullyContained = true;
+    var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
+    var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 10 });
+    var rect3 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 0 });
+    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
+    canvas.add(rect1, rect2, rect3, rect4);
+    canvas._groupSelector = {
+      top: 30,
+      left: 30,
+      ex: -1,
+      ey: -1
+    };
+    var collected = canvas._collectObjects();
+    assert.equal(collected.length, 4, 'a rect that contains all objects collects them all');
+    assert.equal(collected[3], rect1, 'contains rect1 as last object');
+    assert.equal(collected[2], rect2, 'contains rect2');
+    assert.equal(collected[1], rect3, 'contains rect3');
+    assert.equal(collected[0], rect4, 'contains rect4 as first object');
+    canvas.selectionFullyContained = false;
+  });
+
+  QUnit.test('_collectObjects does not collect objects not fully contained', function(assert) {
+    canvas.selectionFullyContained = true;
+    var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
+    var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 10 });
+    var rect3 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 0 });
+    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
+    canvas.add(rect1, rect2, rect3, rect4);
+    canvas._groupSelector = {
+      top: 20,
+      left: 20,
+      ex: 5,
+      ey: 5
+    };
+    var collected = canvas._collectObjects();
+    assert.equal(collected.length, 1, 'a rect intersecting objects does not collect those');
+    assert.equal(collected[0], rect4, 'contains rect1 as only one fully contained');
+    canvas.selectionFullyContained = false;
+  });
+
+  QUnit.test('_collectObjects does not collect object if objects are not fully contained inside', function(assert) {
+    canvas.selectionFullyContained = true;
+    var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
+    var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 10 });
+    var rect3 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 0 });
+    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
+    canvas.add(rect1, rect2, rect3, rect4);
+    canvas._groupSelector = {
+      top: 20,
+      left: 20,
+      ex: 0,
+      ey: 0
+    };
+    var collected = canvas._collectObjects();
+    assert.equal(collected.length, 0, 'a rect not fully including objects do not collect any of them');
+    canvas.selectionFullyContained = false;
+  });
+
   QUnit.test('_fireSelectionEvents fires multiple things', function(assert) {
     var rect1Deselected = false;
     var rect3Selected = false;


### PR DESCRIPTION
Because today selection works as soon as an object intersects with the selection rect. but some use cases require a distance of 100% before a selection can happen.

A common pattern for these kind of option (like jquery.ui selectable) is a distance ratio but the tools classes around intersection computing does not yet return distance of intersection in % so a simple boolean to act like 0 or 100 is fine, non breaking (because false by default) and open the path to a future possibility to a distance ratio.

I'm just not sure about the naming, open to any suggestion on it.

close #3102