### PR TITLE
handle top canvas in resize/renderAll

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -374,6 +374,9 @@
         this.clearContext(this.contextTop);
         this.contextTopDirty = false;
       }
+      if (this.isDrawingMode && this._isCurrentlyDrawing) {
+        this.freeDrawingBrush && this.freeDrawingBrush._render();
+      }
       var canvasToDrawOn = this.contextContainer;
       this.renderCanvas(canvasToDrawOn, this._chooseObjectsToRender());
       return this;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -605,6 +605,9 @@
           this._setCssDimension(prop, cssValue);
         }
       }
+      if (this._isCurrentlyDrawing) {
+        this.freeDrawingBrush && this.freeDrawingBrush._setBrushStyles();
+      }
       this._initRetinaScaling();
       this._setImageSmoothing();
       this.calcOffset();

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -2159,6 +2159,22 @@
     assert.equal(isClick, true, 'without moving the pointer, the click is true');
   });
 
+  QUnit.test('setDimensions and active brush', function(assert) {
+    var prepareFor = false;
+    var rendered = false;
+    var canva = new fabric.Canvas(null, { width: 500, height: 500 });
+    var brush = new fabric.PencilBrush({ color: 'red', width: 4 });
+    canva.isDrawingMode = true;
+    canva.freeDrawingBrush = brush;
+    canva._isCurrentlyDrawing = true;
+    brush._render = function() { rendered = true; };
+    brush._setBrushStyles = function() { prepareFor = true; };
+    canva.setDimensions({ width: 200, height: 200 });
+    canva.renderAll();
+    assert.equal(rendered, true, 'the brush called the _render method');
+    assert.equal(prepareFor, true, 'the brush called the _setBrushStyles method');
+  });
+
   QUnit.test('mouse:up isClick = false', function(assert) {
     var e = { clientX: 30, clientY: 30, which: 1 };
     var e2 = { clientX: 31, clientY: 31, which: 1 };


### PR DESCRIPTION
close #4522 

As reported in the issue, the setDimensions wipes the context and does not refresh current options.
This takes care of the issue resetting the brush options and taking also care of re rendering the brush in renderAll.