### PR TITLE
Extra closepath on control drawing

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -175,7 +175,6 @@
         ctx.beginPath();
         ctx.moveTo(0, rotateHeight);
         ctx.lineTo(0, rotateHeight - rotatingPointOffset);
-        ctx.closePath();
         ctx.stroke();
       }
 


### PR DESCRIPTION
close #4545 

On some hardware configuration the rotation segment creates an unwanted triangle with a random point