### PR TITLE
Fix testem runner, and further improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
 language: node_js
 node_js:
-  - "9"
-  - "8"
   - "6"
-  - "4"
-script: 'npm run build && npm run test && npm run lint && npm run lint_tests'
+
+env:
+  global:
+    - LAUNCHER=Node
+
+matrix:
+  include:
+    - env: LAUNCHER=Chrome
+    - env: LAUNCHER=Firefox
+    - node_js: "9"
+    - node_js: "8"
+    - node_js: "6"
+    - node_js: "4"
+  allow_failures:
+    - env: LAUNCHER=Firefox
+
+script: 'npm run lint && npm run lint_tests && npm run build && testem ci --port 8080 -f testem.json -l $LAUNCHER'
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libc6 libgif-dev libpng-dev libjpeg8-dev libpango1.0-dev libcairo2-dev
+  - if [ "$LAUNCHER" == "Node" ]; then sudo apt-get update -qq; fi
+  - if [ "$LAUNCHER" == "Node" ]; then sudo apt-get install -qq libgif-dev libpng-dev libjpeg8-dev libpango1.0-dev libcairo2-dev; fi
+
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,12 @@ env:
 
 matrix:
   include:
-    - env: LAUNCHER=Chrome
     - env: LAUNCHER=Firefox
+    - env: LAUNCHER=Chrome
     - node_js: "9"
     - node_js: "8"
     - node_js: "6"
     - node_js: "4"
-  allow_failures:
-    - env: LAUNCHER=Firefox
 
 script: 'npm run lint && npm run lint_tests && npm run build && testem ci --port 8080 -f testem.json -l $LAUNCHER'
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
- {
+{
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
@@ -20,15 +20,15 @@
     "HTML5",
     "object model"
   ],
-  "browser" : {
+  "browser": {
     "canvas": false,
-    "fs":      false,
-    "jsdom":   false,
+    "fs": false,
+    "jsdom": false,
     "jsdom/lib/jsdom/living/generated/utils": false,
     "jsdom/lib/jsdom/utils": false,
-    "http":   false,
-    "https":   false,
-    "xmldom":  false,
+    "http": false,
+    "https": false,
+    "xmldom": false,
     "url": false
   },
   "repository": {
@@ -49,7 +49,9 @@
     "lint_tests": "eslint test/unit --config .eslintrc_tests",
     "export_dist_to_site": "cp dist/fabric.js ../fabricjs.com/lib/fabric.js && cp package.json ../fabricjs.com/lib/package.json && cp -r src HEADER.js lib ../fabricjs.com/build/files/",
     "export_tests_to_site": "cp test/unit/*.js ../fabricjs.com/test/unit",
-    "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site"
+    "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site",
+    "testem": "testem .",
+    "testem:ci": "testem ci"
   },
   "optionalDependencies": {
     "canvas": "1.6.x",
@@ -57,12 +59,13 @@
     "xmldom": "0.1.x"
   },
   "devDependencies": {
-    "uglify-js": "3.1.x",
     "eslint": "4.7.x",
+    "istanbul": "0.4.x",
+    "onchange": "^3.x.x",
     "qunit": "1.x.x",
     "qunitjs": "^1.23.1",
-    "istanbul": "0.4.x",
-    "onchange": "^3.x.x"
+    "testem": "^1.18.4",
+    "uglify-js": "3.1.x"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "uglify-js": "3.1.x",
     "eslint": "4.7.x",
     "qunit": "1.x.x",
+    "qunitjs": "^1.23.1",
     "istanbul": "0.4.x",
     "onchange": "^3.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "export_dist_to_site": "cp dist/fabric.js ../fabricjs.com/lib/fabric.js && cp package.json ../fabricjs.com/lib/package.json && cp -r src HEADER.js lib ../fabricjs.com/build/files/",
     "export_tests_to_site": "cp test/unit/*.js ../fabricjs.com/test/unit",
     "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site",
-
-    "test:node": "qunit test/node_test_setup.js test/lib test/unit",
+    "test:node": "./node_modules/qunit/bin/qunit test/node_test_setup.js test/lib test/unit",
     "testem": "testem .",
     "testem:ci": "testem ci"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "eslint": "4.7.x",
     "istanbul": "0.4.x",
+    "node-qunit": "^1.0.0",
     "onchange": "^3.x.x",
     "qunit": "1.x.x",
     "qunitjs": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "istanbul": "0.4.x",
     "node-qunit": "^1.0.0",
     "onchange": "^3.x.x",
-    "qunitjs": "^1.23.1",
     "qunit": "^2.4.1",
     "testem": "^1.18.4",
     "uglify-js": "3.1.x"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "export_dist_to_site": "cp dist/fabric.js ../fabricjs.com/lib/fabric.js && cp package.json ../fabricjs.com/lib/package.json && cp -r src HEADER.js lib ../fabricjs.com/build/files/",
     "export_tests_to_site": "cp test/unit/*.js ../fabricjs.com/test/unit",
     "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site",
+
+    "test:node": "qunit test/node_test_setup.js test/lib test/unit",
     "testem": "testem .",
     "testem:ci": "testem ci"
   },
@@ -63,8 +65,8 @@
     "istanbul": "0.4.x",
     "node-qunit": "^1.0.0",
     "onchange": "^3.x.x",
-    "qunit": "1.x.x",
     "qunitjs": "^1.23.1",
+    "qunit": "^2.4.1",
     "testem": "^1.18.4",
     "uglify-js": "3.1.x"
   },

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var testrunner = require('qunit');
+var testrunner = require('node-qunit');
 
 testrunner.options.log.summary = true;
 testrunner.options.log.tests = false;

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,0 +1,2 @@
+// set the fabric famework as a global for tests
+global.fabric = require('../dist/fabric').fabric;

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,2 +1,5 @@
 // set the fabric famework as a global for tests
 global.fabric = require('../dist/fabric').fabric;
+
+QUnit.config.testTimeout = 10000;
+QUnit.config.noglobals = true;

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -487,9 +487,11 @@
   });
 
   QUnit.test('toDataURL cropping', function(assert) {
+    var done = assert.async();
     assert.ok(typeof canvas.toDataURL === 'function');
     if (!fabric.Canvas.supports('toDataURL')) {
       window.alert('toDataURL is not supported by this environment. Some of the tests can not be run.');
+      done();
     }
     else {
       var croppingWidth = 75,
@@ -499,6 +501,7 @@
       fabric.Image.fromURL(dataURL, function (img) {
         assert.equal(img.width, croppingWidth, 'Width of exported image should correspond to cropping width');
         assert.equal(img.height, croppingHeight, 'Height of exported image should correspond to cropping height');
+        done();
       });
     }
   });

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -273,6 +273,7 @@
 
     iText.exitEditing();
     assert.ok(!iText.isEditing);
+    iText.abortCursorAnimation();
   });
 
   /*  QUnit.test('enterEditing, exitEditing eventlistener counts', function(assert) {
@@ -330,6 +331,7 @@
     assert.equal(enter, 2);
     assert.equal(exit, 2);
     assert.equal(modify, 1);
+    iText.abortCursorAnimation();
   });
 
   // TODO: read those and make tests for new functions
@@ -786,6 +788,7 @@
     var iText = new fabric.IText('test foo bar-baz\nqux');
     iText.enterEditing();
     assert.equal(iText.hiddenTextarea.wrap, 'off', 'HiddenTextarea needs wrap off attribute');
+    iText.abortCursorAnimation();
   });
 
   // QUnit.test('measuring width of words', function (assert) {

--- a/test/unit/itext_key_behaviour.js
+++ b/test/unit/itext_key_behaviour.js
@@ -125,6 +125,8 @@
     assert.equal(iText.selectionStart, 28, 'should move to selection Start');
     assert.equal(iText.selectionEnd, 28, 'should move to selection Start');
     selection = 0;
+    // needed or test hangs
+    iText.abortCursorAnimation();
     // TODO verify and dp
     // iText.selectionStart = 0;
     // iText.selectionEnd = 0;
@@ -236,6 +238,8 @@
     assert.equal(iText.selectionStart, 30, 'should not move');
     assert.equal(iText.selectionEnd, 31, 'should not move');
     selection = 0;
+    // needed or test hangs
+    iText.abortCursorAnimation();
   });
   // QUnit.test('copy and paste', function(assert) {
   //   var event = { stopPropagation: function(){}, preventDefault: function(){} };

--- a/test/unit/pattern.js
+++ b/test/unit/pattern.js
@@ -79,7 +79,7 @@
     assert.equal(object.offsetY, 0);
 
     var patternWithGetSource = new fabric.Pattern({
-      source: function() {return fabric.document.createElement('canvas');}
+      source: function () {return fabric.document.createElement('canvas');}
     });
 
     var object2 = patternWithGetSource.toObject();

--- a/testem.json
+++ b/testem.json
@@ -15,11 +15,13 @@
   },
   "launch_in_dev": [
     "Chrome",
-    "Node"
+    "Node",
+    "Firefox"
   ],
   "launch_in_ci": [
     "Chrome",
-    "Node"
+    "Node",
+    "Firefox"
   ],
   "launchers": {
     "Node": {

--- a/testem.json
+++ b/testem.json
@@ -4,8 +4,14 @@
     "dist/fabric.js",
     "test/unit/*.js"
   ],
+  "routes": {
+    "/fixtures": "test/fixtures"
+  },
   "test_page": "tests.mustache?hidepassed",
   "launch_in_dev": [
+    "Chrome", "Node"
+  ],
+  "launch_in_ci": [
     "Chrome", "Node"
   ],
   "launchers": {

--- a/testem.json
+++ b/testem.json
@@ -1,4 +1,5 @@
 {
+  "framework": "qunit",
   "serve_files": [
     "test/fixtures/test_script.js",
     "dist/fabric.js",
@@ -7,16 +8,23 @@
   "routes": {
     "/fixtures": "test/fixtures"
   },
-  "test_page": "tests.mustache?hidepassed",
+  "test_page": "tests.mustache?hidepassed&hideskipped&timeout=60000",
+  "browser_args": {
+    "Chrome": [ "--headless", "--disable-gpu", "--remote-debugging-port=9222" ],
+    "Firefox": [ "--headless" ]
+  },
   "launch_in_dev": [
-    "Chrome", "Node"
+    "Chrome",
+    "Node"
   ],
   "launch_in_ci": [
-    "Chrome", "Node"
+    "Chrome",
+    "Node"
   ],
   "launchers": {
     "Node": {
-      "command": "node test.js"
+      "command": "npm run test:node",
+      "protocol": "tap"
     }
   },
   "timeout": 540,

--- a/tests.mustache
+++ b/tests.mustache
@@ -2,10 +2,10 @@
 <html>
 <head>
 <title>Test'em</title>
-<script src="/node_modules/qunitjs/qunit/qunit.js"></script>
+<script src="/node_modules/qunit/qunit/qunit.js"></script>
 <script src="/testem.js"></script>
 {{#serve_files}}<script src="{{{src}}}"{{#attrs}} {{&.}}{{/attrs}}></script>{{/serve_files}}
-<link rel="stylesheet" href="/node_modules/qunitjs/qunit/qunit.css"/>
+<link rel="stylesheet" href="/node_modules/qunit/qunit/qunit.css"/>
 {{#styles}}<link rel="stylesheet" href="{{.}}">{{/styles}}
 </head>
 <body>

--- a/tests.mustache
+++ b/tests.mustache
@@ -2,10 +2,10 @@
 <html>
 <head>
 <title>Test'em</title>
-<script src="/bower_components/qunit/qunit/qunit.js"></script>
+<script src="/node_modules/qunitjs/qunit/qunit.js"></script>
 <script src="/testem.js"></script>
 {{#serve_files}}<script src="{{{src}}}"{{#attrs}} {{&.}}{{/attrs}}></script>{{/serve_files}}
-<link rel="stylesheet" href="/bower_components/qunit/qunit/qunit.css"/>
+<link rel="stylesheet" href="/node_modules/qunitjs/qunit/qunit.css"/>
 {{#styles}}<link rel="stylesheet" href="{{.}}">{{/styles}}
 </head>
 <body>


### PR DESCRIPTION
This is some work to get testem working again, in parallel with the existing approach.
It's a work-in-progress, but I wanted to start a pull request to share what I've been doing.

## Improvements in these changes:

- Fixes testem test runner
- CI testing on Chrome, in addition to Node (with Firefox to come close behind)
- Chrome, Firefox configured to run in headless mode
- `npm run testem` script for testem TDD
- `npm run testem:ci` script to hopefully replace `npm test`
- `npm run test:node` script to only run node tests
- Upgrades qunit to version 2.4.1 for testem, and switches to `node-qunit` for existing test script.
- Configured sensible qunit testTimeout (10 seconds) and noglobals=true configs
- Fixes one test that needed to be asynchronous

## TODO:

- [x] Ensure travis builds can use testem by updating Travis config
- [x] Resolve iText tests hanging
- [x] Resolve Firefox failures
- [ ] Decide how to do code coverage in this setup

---

Helps to resolve #3326 
Note however, that these changes do not make use of Saucelabs.