### PR TITLE
Introduced .npmrc file to prevent package-lock files being created

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
I assume that because there is no package-lock file in the project, then we don't want one to ever be committed. This will prevent anyone creating one during `npm install`