### PR TITLE
Update use of getBoundingRect in Guides Example

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -85,8 +85,9 @@ function initAligningGuidelines(canvas) {
       var objectCenter = canvasObjects[i].getCenterPoint(),
           objectLeft = objectCenter.x,
           objectTop = objectCenter.y,
-          objectHeight = canvasObjects[i].getBoundingRect().height / viewportTransform[3],
-          objectWidth = canvasObjects[i].getBoundingRect().width / viewportTransform[0];
+          objectBoundingRect = canvasObjects[i].getBoundingRect(),
+          objectHeight = objectBoundingRect.height / viewportTransform[3],
+          objectWidth = objectBoundingRect.width / viewportTransform[0];
 
       // snap by the horizontal center line
       if (isInRange(objectLeft, activeObjectLeft)) {

--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -66,8 +66,9 @@ function initAligningGuidelines(canvas) {
         activeObjectCenter = activeObject.getCenterPoint(),
         activeObjectLeft = activeObjectCenter.x,
         activeObjectTop = activeObjectCenter.y,
-        activeObjectHeight = activeObject.getBoundingRectHeight() / viewportTransform[3],
-        activeObjectWidth = activeObject.getBoundingRectWidth() / viewportTransform[0],
+        activeObjectBoundingRect = activeObject.getBoundingRect(),
+        activeObjectHeight = activeObjectBoundingRect.height / viewportTransform[3],
+        activeObjectWidth = activeObjectBoundingRect.width / viewportTransform[0],
         horizontalInTheRange = false,
         verticalInTheRange = false,
         transform = canvas._currentTransform;
@@ -84,8 +85,8 @@ function initAligningGuidelines(canvas) {
       var objectCenter = canvasObjects[i].getCenterPoint(),
           objectLeft = objectCenter.x,
           objectTop = objectCenter.y,
-          objectHeight = canvasObjects[i].getBoundingRectHeight() / viewportTransform[3],
-          objectWidth = canvasObjects[i].getBoundingRectWidth() / viewportTransform[0];
+          objectHeight = canvasObjects[i].getBoundingRect().height / viewportTransform[3],
+          objectWidth = canvasObjects[i].getBoundingRect().width / viewportTransform[0];
 
       // snap by the horizontal center line
       if (isInRange(objectLeft, activeObjectLeft)) {


### PR DESCRIPTION
Aligning Guidelines Example broken. Update to use getBoundingRect() function