### PR TITLE
fix calcOffset when text enter editing

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -333,6 +333,7 @@
       }
 
       if (this.canvas) {
+        this.canvas.calcOffset();
         this.exitEditingOnOthers(this.canvas);
       }
 


### PR DESCRIPTION
When Text enter editing, it needs to position the hiddenTextarea to match the text position.
To do so it uses canvas._offset point.

If canvas._offset point has never been calculated, the position is wrong.

