### PR TITLE
Update example in brightness_filter documentation

### DIFF
--- a/src/filters/brightness_filter.class.js
+++ b/src/filters/brightness_filter.class.js
@@ -15,7 +15,7 @@
    * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
    * @example
    * var filter = new fabric.Image.filters.Brightness({
-   *   brightness: 200
+   *   brightness: 0.05
    * });
    * object.filters.push(filter);
    * object.applyFilters();


### PR DESCRIPTION
The value range for brightness changed to floating point range [-1.0,1.0]
The documentation is outdated.