### PR TITLE
Fixed incorrect Object.isOnScreen functionality.

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -176,12 +176,12 @@
         }
       }
       // no points on screen, check intersection with absolute coordinates
-      if (this.intersectsWithRect(pointTL, pointBR, true)) {
+      if (this.intersectsWithRect(pointTL, pointBR, true, calculate)) {
         return true;
       }
       // worst case scenario the object is so big that contains the screen
       var centerPoint = { x: (pointTL.x + pointBR.x) / 2, y: (pointTL.y + pointBR.y) / 2 };
-      if (this.containsPoint(centerPoint, null, true)) {
+      if (this.containsPoint(centerPoint, null, true, calculate)) {
         return true;
       }
       return false;

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -324,6 +324,7 @@
     cObj.setCoords();
     assert.ok(cObj.isOnScreen(), 'object is onScreen');
     cObj.top = 1000;
+    assert.ok(!cObj.isOnScreen(true), 'object is not onScreen with top 1000 with calculate true and no setCoords call');
     cObj.setCoords();
     assert.ok(!cObj.isOnScreen(), 'object is not onScreen with top 1000');
     canvas.setZoom(0.1);

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -324,6 +324,7 @@
     cObj.setCoords();
     assert.ok(cObj.isOnScreen(), 'object is onScreen');
     cObj.top = 1000;
+    assert.ok(cObj.isOnScreen(), 'object is still wrongly on screen since setCoords is not called and calculate is not set, even when top is already at 1000');
     assert.ok(!cObj.isOnScreen(true), 'object is not onScreen with top 1000 with calculate true and no setCoords call');
     cObj.setCoords();
     assert.ok(!cObj.isOnScreen(), 'object is not onScreen with top 1000');


### PR DESCRIPTION
I have not found any usages of Object.isOnScreen being called with calculate = false. I thought about removing it but, was not sure. Hence, left it as it is, added a couple more tests, removed setCoords calls that were kind of bypassing the functionality being tested.