### PR TITLE
Use clientWidth and clientHeight of upperCanvas to size hiddenTextarea

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -525,8 +525,8 @@
             y: boundaries.top + boundaries.topOffset + charHeight
           },
           upperCanvas = this.canvas.upperCanvasEl,
-          maxWidth = upperCanvas.width - charHeight,
-          maxHeight = upperCanvas.height - charHeight;
+          maxWidth = upperCanvas.clientWidth - charHeight,
+          maxHeight = upperCanvas.clientHeight - charHeight;
 
       p = fabric.util.transformPoint(p, m);
       p = fabric.util.transformPoint(p, this.canvas.viewportTransform);

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -525,8 +525,10 @@
             y: boundaries.top + boundaries.topOffset + charHeight
           },
           upperCanvas = this.canvas.upperCanvasEl,
-          maxWidth = upperCanvas.clientWidth - charHeight,
-          maxHeight = upperCanvas.clientHeight - charHeight;
+          upperCanvasWidth = upperCanvas.clientWidth || upperCanvas.width,
+          upperCanvasHeight = upperCanvas.clientHeight || upperCanvas.height,
+          maxWidth = upperCanvasWidth - charHeight,
+          maxHeight = upperCanvasHeight - charHeight;
 
       p = fabric.util.transformPoint(p, m);
       p = fabric.util.transformPoint(p, this.canvas.viewportTransform);

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -791,6 +791,46 @@
     iText.abortCursorAnimation();
   });
 
+  QUnit.test('hiddenTextarea does not move DOM', function(assert) {
+    if (fabric.isLikelyNode) {
+      assert.ok(true);
+      return;
+    }
+
+    var el = fabric.document.createElement('div');
+    el.id = 'itext-test-wrapper';
+    el.style.width = '100px';
+    el.style.height = '65px';
+    el.innerHTML = '<canvas id="itext-test-canvas" style="width: 100%; height: 100%;"></canvas>';
+
+    fabric.document.body.appendChild(el);
+
+    var iText = new fabric.IText('Double-click to edit', { fill: '#ffffff', fontSize: 50 });
+
+    var canvas = new fabric.Canvas('itext-test-canvas', { width: 2800, height: 1600, renderOnAddRemove: true });
+    canvas.setDimensions({'max-height': '100%', 'max-width': '100%'}, { cssOnly: true });
+    canvas.renderAll();
+
+    iText.set({
+      top: canvas.height - iText.height,
+      left: canvas.width - iText.width
+    });
+    canvas.add(iText);
+
+    var widthBeforeEdit = fabric.document.documentElement.scrollWidth,
+        heightBeforeEdit = fabric.document.documentElement.scrollHeight;
+
+    iText.enterEditing();
+
+    var widthAfterEdit = fabric.document.documentElement.scrollWidth,
+        heightAfterEdit = fabric.document.documentElement.scrollHeight;
+
+    iText.exitEditing();
+
+    assert.equal(widthAfterEdit, widthBeforeEdit, 'Adding hiddenTextarea modified DOM width');
+    assert.equal(heightAfterEdit, heightBeforeEdit, 'Adding hiddenTextarea modified DOM height');
+  });
+
   // QUnit.test('measuring width of words', function (assert) {
   //   var ctx = canvas.getContext('2d');
   //   var text = 'test foo bar';

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -807,15 +807,15 @@
 
     var iText = new fabric.IText('Double-click to edit', { fill: '#ffffff', fontSize: 50 });
 
-    var canvas = new fabric.Canvas('itext-test-canvas', { width: 2800, height: 1600, renderOnAddRemove: true });
-    canvas.setDimensions({'max-height': '100%', 'max-width': '100%'}, { cssOnly: true });
-    canvas.renderAll();
+    var canvas2 = new fabric.Canvas('itext-test-canvas', { width: 2800, height: 1600, renderOnAddRemove: true });
+    canvas2.setDimensions({'max-height': '100%', 'max-width': '100%'}, { cssOnly: true });
+    canvas2.renderAll();
 
     iText.set({
-      top: canvas.height - iText.height,
-      left: canvas.width - iText.width
+      top: canvas2.height - iText.height,
+      left: canvas2.width - iText.width
     });
-    canvas.add(iText);
+    canvas2.add(iText);
 
     var widthBeforeEdit = fabric.document.documentElement.scrollWidth,
         heightBeforeEdit = fabric.document.documentElement.scrollHeight;
@@ -829,6 +829,9 @@
 
     assert.equal(widthAfterEdit, widthBeforeEdit, 'Adding hiddenTextarea modified DOM width');
     assert.equal(heightAfterEdit, heightBeforeEdit, 'Adding hiddenTextarea modified DOM height');
+
+    canvas2.dispose();
+    el.parentNode.removeChild(el);
   });
 
   // QUnit.test('measuring width of words', function (assert) {


### PR DESCRIPTION
Use clientWidth and clientHeight of upperCanvas to size hiddenTextarea to work with dynamic sized canvas.

See https://github.com/kangax/fabric.js/issues/4767