### PR TITLE
getHeightOfLine not measuring empty lines

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -767,8 +767,11 @@
         return this.__lineHeights[lineIndex];
       }
 
-      var line = this._textLines[lineIndex], maxHeight = 0;
-      for (var i = 0, len = line.length; i < len; i++) {
+      var line = this._textLines[lineIndex],
+          // char 0 is measured before the line cycle because it nneds to char
+          // emptylines
+          maxHeight = this.getHeightOfChar(lineIndex, 0);
+      for (var i = 1, len = line.length; i < len; i++) {
         maxHeight = Math.max(this.getHeightOfChar(lineIndex, i), maxHeight);
       }
 

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -717,4 +717,13 @@
     assert.equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize has been decreased');
     assert.equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been increased');
   });
+
+  QUnit.test('getHeightOfLine measures height of aline', function(assert) {
+    var text = new fabric.Text('xxx\n');
+    var height1 = text.getHeightOfLine(0);
+    var height2 = text.getHeightOfLine(1);
+    assert.equal(Math.round(height1), 52, 'height of line with text is ok');
+    assert.equal(Math.round(height2), 52, 'height of empty line is ok');
+    assert.equal(height1, height2, 'should have same height');
+  });
 })();


### PR DESCRIPTION
Restored code as before the superscript changes.
Added a test to avoid doing the same mistake next time
close #4798