### PR TITLE
Fix getPointer on touch devices

### DIFF
--- a/src/util/dom_event.js
+++ b/src/util/dom_event.js
@@ -212,11 +212,17 @@
 
   function _getPointer(event, pageProp, clientProp) {
     var touchProp = event.type === 'touchend' ? 'changedTouches' : 'touches';
+    var pointer;
 
-    return (event[touchProp] && event[touchProp][0]
-      ? (event[touchProp][0][pageProp] - (event[touchProp][0][pageProp] - event[touchProp][0][clientProp]))
-        || event[clientProp]
-      : event[clientProp]);
+    if (event[touchProp] && event[touchProp][0]) {
+      pointer = event[touchProp][0][pageProp] - (event[touchProp][0][pageProp] - event[touchProp][0][clientProp]);
+    }
+
+    if (typeof pointer === 'undefined') {
+      pointer = event[clientProp];
+    }
+
+    return pointer;
   }
 
   if (fabric.isTouchSupported) {

--- a/src/util/dom_event.js
+++ b/src/util/dom_event.js
@@ -212,10 +212,10 @@
 
   function _getPointer(event, pageProp, clientProp) {
     var touchProp = event.type === 'touchend' ? 'changedTouches' : 'touches';
-    var pointer;
+    var pointer, eventTouchProp = event[touchProp];
 
-    if (event[touchProp] && event[touchProp][0]) {
-      pointer = event[touchProp][0][pageProp] - (event[touchProp][0][pageProp] - event[touchProp][0][clientProp]);
+    if (eventTouchProp && eventTouchProp[0]) {
+      pointer = eventTouchProp[0][clientProp];
     }
 
     if (typeof pointer === 'undefined') {


### PR DESCRIPTION
When dragging an object on touch device on top or left edge of a screen, the getPointer function returns an incorrect value (NaN).  
To reproduce it, you can use the following demo : http://fabricjs.com/intersection and move an object to the left side. 

When clientX and pageX are 0, the internal _getPointer method returns event[clientProp] which is undefined instead of 0.