### PR TITLE
Fixing issues with selectionDashArray bleeding into free drawing (#4894)

### DIFF
--- a/src/brushes/base_brush.class.js
+++ b/src/brushes/base_brush.class.js
@@ -78,8 +78,8 @@ fabric.BaseBrush = fabric.util.createClass(/** @lends fabric.BaseBrush.prototype
     ctx.lineCap = this.strokeLineCap;
     ctx.miterLimit = this.strokeMiterLimit;
     ctx.lineJoin = this.strokeLineJoin;
-    if (this.strokeDashArray && fabric.StaticCanvas.supports('setLineDash')) {
-      ctx.setLineDash(this.strokeDashArray);
+    if (fabric.StaticCanvas.supports('setLineDash')) {
+      ctx.setLineDash(this.strokeDashArray || []);
     }
   },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1134,7 +1134,6 @@
           aleft,
           atop
         );
-        fabric.Object.prototype._setLineDash.call(this, ctx, []);
       }
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1134,6 +1134,7 @@
           aleft,
           atop
         );
+        fabric.Object.prototype._setLineDash.call(this, ctx, []);
       }
     },
 


### PR DESCRIPTION
close #4894

Proposed fix: call `setLineDash` on an empty dash array once the selection box is done drawing.